### PR TITLE
ENH: Rewrite first level analysis as Nipype workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # pull request on our GitHub repository:
 #     https://github.com/kaczmarj/neurodocker
 #
-# Timestamp: 2018-03-08 22:26:14
+# Timestamp: 2018-04-18 20:02:44
 
 FROM neurodebian@sha256:5fbbad8c68525b588a459092254094436aae9dc1f3920f8d871a03053b10377c
 
@@ -82,6 +82,7 @@ RUN conda install -y -q --name neuro numpy=1.14.1 \
                                      scikit-learn=0.19.1 \
                                      matplotlib=2.1.2 \
                                      seaborn=0.8.1 \
+                                     pytables=3.4.2 \
                                      pandas=0.22.0 \
                                      nipype=1.0.1 \
                                      patsy \
@@ -173,7 +174,7 @@ RUN echo '{ \
     \n      "miniconda", \
     \n      { \
     \n        "env_name": "neuro", \
-    \n        "conda_install": "numpy=1.14.1 scipy=1.0.0 scikit-learn=0.19.1 matplotlib=2.1.2 seaborn=0.8.1 pandas=0.22.0 nipype=1.0.1 patsy" \
+    \n        "conda_install": "numpy=1.14.1 scipy=1.0.0 scikit-learn=0.19.1 matplotlib=2.1.2 seaborn=0.8.1 pytables=3.4.2 pandas=0.22.0 nipype=1.0.1 patsy" \
     \n      } \
     \n    ], \
     \n    [ \
@@ -233,6 +234,6 @@ RUN echo '{ \
     \n      } \
     \n    ] \
     \n  ], \
-    \n  "generation_timestamp": "2018-03-08 22:26:14", \
+    \n  "generation_timestamp": "2018-04-18 20:02:44", \
     \n  "neurodocker_version": "0.3.2" \
     \n}' > /neurodocker/neurodocker_specs.json

--- a/fitlins/__about__.py
+++ b/fitlins/__about__.py
@@ -35,6 +35,7 @@ REQUIRES = [
     'numpy>=1.11',
     'nilearn>=0.4.0',
     'pandas>=0.19',
+    'tables>=3.2.1',
     'nistats>=0.0.1a',
     'pybids>=0.5.1',
     'jinja2',

--- a/fitlins/__about__.py
+++ b/fitlins/__about__.py
@@ -37,11 +37,14 @@ REQUIRES = [
     'pandas>=0.19',
     'tables>=3.2.1',
     'nistats>=0.0.1a',
+    'grabbit>=0.1.1',
     'pybids>=0.5.1',
     'jinja2',
 ]
 
 LINKS_REQUIRES = [
+    'git+https://github.com/grabbles/grabbit.git@'
+    '3fe38c7e7eb510a38e6c2d072bdc913aaa1b7389#egg=grabbit-0.1.2-dev',
     'git+https://github.com/nistats/nistats.git@'
     'ce3695e8f34c6f34323766dc96a60a53b69d2729#egg=nistats-0.0.1b-dev',
 ]

--- a/fitlins/base.py
+++ b/fitlins/base.py
@@ -10,7 +10,7 @@ import pandas as pd
 import nibabel as nb
 from nilearn import plotting as nlp
 import nistats as nis
-import nistats.reporting
+import nistats.reporting  # noqa: F401
 from nistats import design_matrix as dm
 from nistats import first_level_model as level1, second_level_model as level2
 

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -72,7 +72,7 @@ def get_parser():
     parser.add_argument('-v', '--version', action='version', version=verstr)
 
     g_bids = parser.add_argument_group('Options for filtering BIDS queries')
-    g_bids.add_argument('--participant-label', action='store', nargs='+',
+    g_bids.add_argument('--participant-label', action='store', nargs='+', default=[],
                         help='one or more participant identifiers (the sub- prefix can be '
                              'removed)')
     g_bids.add_argument('-m', '--model', action='store', default='model.json',
@@ -128,8 +128,8 @@ def create_workflow(opts):
     # BIDS-Apps prefers 'participant', BIDS-Model prefers 'subject'
     level = 'subject' if opts.analysis_level == 'participant' else opts.analysis_level
 
-    fitlins_wf = init_fitlins_wf(bids_dir, preproc_dir, deriv_dir, opts.space,
-                                 model, base_dir=opts.work_dir)
+    fitlins_wf = init_fitlins_wf(bids_dir, preproc_dir, deriv_dir, opts.space, model,
+                                 subject_list, base_dir=opts.work_dir)
 
     try:
         fitlins_wf.run(plugin='MultiProc')

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -20,7 +20,7 @@ from bids.analysis import Analysis
 from .. import __version__
 from ..workflows import init_fitlins_wf
 from ..utils import bids
-from ..base import init, first_level, second_level
+from ..base import init, second_level
 from ..viz.reports import write_report, parse_directory
 
 logging.addLevelName(25, 'INFO')  # Add a new level between INFO and WARNING

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -1,0 +1,70 @@
+import nibabel as nb
+from nipype.interfaces.base import (
+    BaseInterfaceInputSpec, TraitedSpec, SimpleInterface,
+    InputMultiPath, File, Directory,
+    traits, isdefined
+    )
+from bids import grabbids as gb, analysis as ba
+
+
+class LoadLevel1BIDSModelInputSpec(BaseInterfaceInputSpec):
+    bids_dirs = InputMultiPath(Directory(exists=True),
+                               mandatory=True,
+                               desc='BIDS dataset root directories')
+    model = File(exists=True, desc='Model filename')
+    selectors = traits.Dict(desc='Limit collected sessions')
+
+
+class LoadLevel1BIDSModelOutputSpec(TraitedSpec):
+    session_info = traits.List(traits.Dict())
+    contrast_info = traits.List(traits.Any())
+
+
+class LoadLevel1BIDSModel(SimpleInterface):
+    def _run_interface(self, runtime):
+        layout = gb.BIDSLayout(self.inputs.bids_dirs)
+        model_fname = self.inputs.model
+        if not isdefined(model_fname):
+            models = layout.get(type='model')
+            if len(models) == 1:
+                model_fname = models[0].filename
+            elif models:
+                raise ValueError("Ambiguous model")
+            else:
+                raise ValueError("No models found")
+
+        selectors = self.inputs.selectors if isdefined(self.inputs.selectors) else {}
+
+        analysis = ba.Analysis(model=model_fname, layout=layout)
+        selectors.update(analysis.model['input'])
+        analysis.setup(**selectors)
+        block = analysis.blocks[0]
+
+        session_info = []
+        for paradigm, _, ents in block.get_design_matrix(block.model['HRF_variables'],
+                                                         mode='sparse'):
+            info = {'entities': ents}
+
+            bold_files = layout.get(type='bold',
+                                    extensions=['.nii', '.nii.gz'],
+                                    **ents)
+            if len(bold_files) != 1:
+                raise ValueError('Too many BOLD files found')
+
+            fname = bold_files[0].filename
+
+            # Required field in seconds
+            TR = layout.get_metadata(fname)['RepetitionTime']
+            # vols = nb.load(fname).shape[3]
+
+            _, confounds, _ = block.get_design_matrix(mode='dense',
+                                                      sampling_rate=1/TR,
+                                                      **ents)[0]
+
+            info['events'] = paradigm
+            info['confounds'] = confounds
+
+            session_info.append(info)
+
+        self._results['session_info'] = session_info
+        return runtime

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -50,7 +50,7 @@ def bids_split_filename(fname):
             fname = fname[:-ext_len]
             break
     else:
-        fname, ext = op.splitext(fname)
+        fname, ext = os.path.splitext(fname)
 
     return pth, fname, ext
 

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -12,6 +12,8 @@ from nipype.interfaces.base import (
 from nipype.interfaces.io import IOBase
 from bids import grabbids as gb, analysis as ba
 
+from ..utils import snake_to_camel
+
 
 def bids_split_filename(fname):
     """Split a filename into parts: path, base filename, and extension
@@ -295,6 +297,8 @@ class BIDSDataSink(IOBase):
                                      self.inputs.in_file):
             ents = {**self.inputs.fixed_entities}
             ents.update(entities)
+
+            ents = {k: snake_to_camel(v) for k, v in ents.items()}
 
             out_fname = os.path.join(
                 base_dir, layout.build_path(ents))

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -78,8 +78,8 @@ class LoadLevel1BIDSModel(SimpleInterface):
                                        '{}_events.h5'.format(ent_string))
             confounds_file = os.path.join(runtime.cwd,
                                           '{}_confounds.h5'.format(ent_string))
-            paradigm.to_hdf(events_file)
-            confounds[names].fillna(0).to_hdf(confounds_file)
+            paradigm.to_hdf(events_file, key='events')
+            confounds[names].fillna(0).to_hdf(confounds_file, key='confounds')
             info['events'] = events_file
             info['confounds'] = confounds_file
             info['repetition_time'] = TR

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -13,6 +13,12 @@ class LoadLevel1BIDSModelInputSpec(BaseInterfaceInputSpec):
                                desc='BIDS dataset root directories')
     model = File(exists=True, desc='Model filename')
     selectors = traits.Dict(desc='Limit collected sessions')
+    include_pattern = InputMultiPath(
+        traits.Str, xor=['exclude_pattern'],
+        desc='Patterns to select sub-directories of BIDS root')
+    exclude_pattern = InputMultiPath(
+        traits.Str, xor=['include_pattern'],
+        desc='Patterns to ignore sub-directories of BIDS root')
 
 
 class LoadLevel1BIDSModelOutputSpec(TraitedSpec):
@@ -25,7 +31,14 @@ class LoadLevel1BIDSModel(SimpleInterface):
     output_spec = LoadLevel1BIDSModelOutputSpec
 
     def _run_interface(self, runtime):
-        layout = gb.BIDSLayout(self.inputs.bids_dirs)
+        include = self.inputs.include_pattern
+        exclude = self.inputs.include_pattern
+        if not isdefined(include):
+            include = None
+        if not isdefined(exclude):
+            exclude = None
+        layout = gb.BIDSLayout(self.inputs.bids_dirs, include=include,
+                               exclude=exclude)
         model_fname = self.inputs.model
         if not isdefined(model_fname):
             models = layout.get(type='model')

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -184,6 +184,7 @@ class BIDSSelectInputSpec(BaseInterfaceInputSpec):
 class BIDSSelectOutputSpec(TraitedSpec):
     bold_files = OutputMultiPath(File)
     mask_files = OutputMultiPath(traits.Either(File, None))
+    entities = OutputMultiPath(traits.Dict)
 
 
 class BIDSSelect(SimpleInterface):
@@ -194,6 +195,7 @@ class BIDSSelect(SimpleInterface):
         layout = gb.BIDSLayout(self.inputs.bids_dirs)
         bold_files = []
         mask_files = []
+        entities = []
         for ents in self.inputs.entities:
             selectors = {**self.inputs.selectors, **ents}
             bold_file = layout.get(extensions=['.nii', '.nii.gz'], **selectors)
@@ -218,11 +220,15 @@ class BIDSSelect(SimpleInterface):
             bold_ents['type'] = 'brainmask'
             mask_file = layout.get(extensions=['.nii', '.nii.gz'], **bold_ents)
 
+            bold_ents.pop('type')
+
             bold_files.append(bold_file[0].filename)
             mask_files.append(mask_file[0].filename if mask_file else None)
+            entities.append(bold_ents)
 
         self._results['bold_files'] = bold_files
         self._results['mask_files'] = mask_files
+        self._results['entities'] = entities
 
         return runtime
 

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -21,6 +21,9 @@ class LoadLevel1BIDSModelOutputSpec(TraitedSpec):
 
 
 class LoadLevel1BIDSModel(SimpleInterface):
+    input_spec = LoadLevel1BIDSModelInputSpec
+    output_spec = LoadLevel1BIDSModelOutputSpec
+
     def _run_interface(self, runtime):
         layout = gb.BIDSLayout(self.inputs.bids_dirs)
         model_fname = self.inputs.model

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -1,0 +1,71 @@
+import os
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+import nibabel as nb
+import nistats as nis
+import nistats.reporting
+from nistats import design_matrix as dm
+from nistats import first_level_model as level1, second_level_model as level2
+
+from nipype.interfaces.base import (
+    BaseInterfaceInputSpec, TraitedSpec, SimpleInterface,
+    OutputMultiPath, File,
+    traits, isdefined
+    )
+
+from ..viz import plot_and_save, plot_corr_matrix
+
+
+class FirstLevelModelInputSpec(BaseInterfaceInputSpec):
+    bold_file = File(exists=True, mandatory=True)
+    mask_file = File(exists=True)
+    session_info = traits.Dict()
+    contrast_info = traits.Dict()
+
+
+class FirstLevelModelOutputSpec(TraitedSpec):
+    estimate_maps = OutputMultiPath(File())
+    contrast_maps = OutputMultiPath(File())
+    design_matrix = File()
+    design_matrix_plot = File()
+    correlation_matrix_plot = File()
+    contrast_matrix_plot = File()
+
+
+class FirstLevelModel(SimpleInterface):
+    def _run_interface(self, runtime):
+        info = self.inputs.session_info
+
+        img = nb.load(self.inputs.bold_file)
+        vols = img.shape[3]
+
+        events = pd.read_hdf(info['events'])
+        confounds = pd.read_hdf(info['confounds'])
+
+        mat = dm.make_design_matrix(
+            frame_times=np.arange(vols) * info['repetition_time'],
+            paradigm=events,
+            add_regs=confounds,
+            add_reg_names=confounds.columns,
+            drift_model=None if 'Cosine00' in confounds.columns else 'cosine',
+            )
+
+        plt.set_cmap('viridis')
+        plot_and_save('design.svg', nis.reporting.plot_design_matrix, mat)
+        self._results['design_matrix_plot'] = os.path.join(runtime.cwd,
+                                                           'design.svg')
+
+        plot_and_save('correlation.svg', plot_corr_matrix,
+                      mat.drop(columns='constant').corr(),
+                      len(events.columns))
+        self._results['correlation_matrix_plot'] = os.path.join(
+            runtime.cwd, 'correlation.svg')
+
+        mask_file = self.inputs.mask_file
+        if not isdefined(mask_file):
+            mask_file = None
+        flm = level1.FirstLevelModel(mask=mask_file)
+        flm.fit(img, design_matrices=mat)
+
+        return runtime

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -1,11 +1,10 @@
 import os
-from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
 import nibabel as nb
 from nilearn import plotting as nlp
 import nistats as nis
-import nistats.reporting
+import nistats.reporting  # noqa: F401
 from nistats import design_matrix as dm
 from nistats import first_level_model as level1, second_level_model as level2
 

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -90,6 +90,14 @@ class FirstLevelModel(SimpleInterface):
     output_spec = FirstLevelModelOutputSpec
 
     def _run_interface(self, runtime):
+        import matplotlib
+        matplotlib.use('Agg')
+        import seaborn as sns
+        from matplotlib import pyplot as plt
+        sns.set_style('white')
+        plt.rcParams['svg.fonttype'] = 'none'
+        plt.rcParams['image.interpolation'] = 'nearest'
+
         info = self.inputs.session_info
 
         img = nb.load(self.inputs.bold_file)

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -43,14 +43,15 @@ class FirstLevelModel(SimpleInterface):
         img = nb.load(self.inputs.bold_file)
         vols = img.shape[3]
 
-        events = pd.read_hdf(info['events'])
-        confounds = pd.read_hdf(info['confounds'])
+        events = pd.read_hdf(info['events'], key='events')
+        confounds = pd.read_hdf(info['confounds'], key='confounds')
 
         mat = dm.make_design_matrix(
             frame_times=np.arange(vols) * info['repetition_time'],
-            paradigm=events,
+            paradigm=events.rename(columns={'condition': 'trial_type',
+                                            'amplitude': 'modulation'}),
             add_regs=confounds,
-            add_reg_names=confounds.columns,
+            add_reg_names=confounds.columns.tolist(),
             drift_model=None if 'Cosine00' in confounds.columns else 'cosine',
             )
 

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -14,14 +14,66 @@ from nipype.interfaces.base import (
     traits, isdefined
     )
 
-from ..viz import plot_and_save, plot_corr_matrix
+from ..viz import plot_and_save, plot_corr_matrix, plot_contrast_matrix
+
+
+def build_contrast_matrix(contrast_spec, design_matrix,
+                          identity=None):
+    """Construct contrast matrix and return contrast type
+
+    Parameters
+    ----------
+    contrast_spec : DataFrame
+        Weight matrix with contrasts as rows and regressors as columns
+        May have 'type' column indicating T/F test
+    design_matrix : DataFrame
+        GLM design matrix with regressors as columns and TR time as rows
+    identity : list of strings
+        Names of explanatory variables to ensure "identity" contrasts are
+        provided.
+
+    Returns
+    -------
+    contrast_matrix : DataFrame
+        Weight matrix with contrasts as columns and regressors as rows.
+        Regressors match columns (including order) of design matrix.
+        Identity contrasts are included.
+    contrast_types : Series
+        Series of 'T'/'F' indicating the type of test for each column in
+        the returned contrast matrix.
+        Identity contrasts use T-tests.
+    """
+    # The basic spec is just a transposed matrix with an optional 'type'
+    # column
+    # We'll re-transpose and expand this matrix
+    init_matrix = contrast_spec.drop('type', axis='columns').T
+    init_types = contrast_spec['type'] if 'type' in contrast_spec \
+        else pd.Series()
+
+    if identity is None:
+        identity = []
+    all_cols = init_matrix.columns.tolist()
+    all_cols.extend(set(identity) - set(all_cols))
+
+    contrast_matrix = pd.DataFrame(index=design_matrix.columns,
+                                   columns=all_cols, data=0)
+    contrast_matrix.loc[tuple(init_matrix.axes)] = init_matrix
+
+    contrast_types = pd.Series(index=all_cols, data='T')
+    contrast_types[init_types.index] = init_types
+
+    if identity:
+        contrast_matrix.loc[identity, identity] = np.eye(len(identity))
+        contrast_types[identity] = 'T'
+
+    return contrast_matrix, contrast_types
 
 
 class FirstLevelModelInputSpec(BaseInterfaceInputSpec):
     bold_file = File(exists=True, mandatory=True)
     mask_file = File(exists=True)
     session_info = traits.Dict()
-    contrast_info = traits.Dict()
+    contrast_info = File(exists=True)
 
 
 class FirstLevelModelOutputSpec(TraitedSpec):
@@ -45,6 +97,11 @@ class FirstLevelModel(SimpleInterface):
 
         events = pd.read_hdf(info['events'], key='events')
         confounds = pd.read_hdf(info['confounds'], key='confounds')
+        if isdefined(self.inputs.contrast_info):
+            contrast_spec = pd.read_hdf(self.inputs.contrast_info,
+                                        key='contrasts')
+        else:
+            contrast_spec = pd.DataFrame()
 
         mat = dm.make_design_matrix(
             frame_times=np.arange(vols) * info['repetition_time'],
@@ -55,21 +112,46 @@ class FirstLevelModel(SimpleInterface):
             drift_model=None if 'Cosine00' in confounds.columns else 'cosine',
             )
 
+        exp_vars = events['condition'].unique().tolist()
+
+        contrast_matrix, contrast_types = build_contrast_matrix(contrast_spec,
+                                                                mat, exp_vars)
+
         plt.set_cmap('viridis')
         plot_and_save('design.svg', nis.reporting.plot_design_matrix, mat)
         self._results['design_matrix_plot'] = os.path.join(runtime.cwd,
                                                            'design.svg')
 
         plot_and_save('correlation.svg', plot_corr_matrix,
-                      mat.drop(columns='constant').corr(),
-                      len(events['condition'].unique()))
+                      mat.drop(columns='constant').corr(), len(exp_vars))
         self._results['correlation_matrix_plot'] = os.path.join(
             runtime.cwd, 'correlation.svg')
+
+        plot_and_save('contrast.svg', plot_contrast_matrix,
+                      contrast_matrix.drop(['constant'], 'index'),
+                      ornt='horizontal')
+        self._results['contrast_matrix_plot'] = os.path.join(
+            runtime.cwd, 'contrast.svg')
 
         mask_file = self.inputs.mask_file
         if not isdefined(mask_file):
             mask_file = None
         flm = level1.FirstLevelModel(mask=mask_file)
         flm.fit(img, design_matrices=mat)
+
+        estimate_maps = []
+        contrast_maps = []
+        stat_fmt = os.path.join(runtime.cwd, '{}.nii.gz').format
+        for contrast, ctype in zip(contrast_matrix, contrast_types):
+            stat = flm.compute_contrast(contrast_matrix[contrast].values,
+                                        {'T': 't', 'F': 'F'}[ctype])
+            fname = stat_fmt(contrast)
+            stat.to_filename(fname)
+            if contrast in exp_vars:
+                estimate_maps.append(fname)
+            else:
+                contrast_maps.append(fname)
+        self._results['estimate_maps'] = estimate_maps
+        self._results['contrast_maps'] = contrast_maps
 
         return runtime

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -77,8 +77,10 @@ class FirstLevelModelInputSpec(BaseInterfaceInputSpec):
 
 
 class FirstLevelModelOutputSpec(TraitedSpec):
-    estimate_maps = OutputMultiPath(File())
-    contrast_maps = OutputMultiPath(File())
+    estimate_maps = OutputMultiPath(File)
+    contrast_maps = OutputMultiPath(File)
+    estimate_metadata = OutputMultiPath(traits.Dict)
+    contrast_metadata = OutputMultiPath(traits.Dict)
     design_matrix = File()
     design_matrix_plot = File()
     correlation_matrix_plot = File()
@@ -149,6 +151,8 @@ class FirstLevelModel(SimpleInterface):
 
         estimate_maps = []
         contrast_maps = []
+        estimate_metadata = []
+        contrast_metadata = []
         stat_fmt = os.path.join(runtime.cwd, '{}.nii.gz').format
         for contrast, ctype in zip(contrast_matrix, contrast_types):
             stat = flm.compute_contrast(contrast_matrix[contrast].values,
@@ -157,9 +161,15 @@ class FirstLevelModel(SimpleInterface):
             stat.to_filename(fname)
             if contrast in exp_vars:
                 estimate_maps.append(fname)
+                estimate_metadata.append({'contrast': contrast,
+                                          'type': 'stat'})
             else:
                 contrast_maps.append(fname)
+                contrast_metadata.append({'contrast': contrast,
+                                          'type': 'stat'})
         self._results['estimate_maps'] = estimate_maps
         self._results['contrast_maps'] = contrast_maps
+        self._results['estimate_metadata'] = estimate_metadata
+        self._results['contrast_metadata'] = contrast_metadata
 
         return runtime

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -62,7 +62,7 @@ class FirstLevelModel(SimpleInterface):
 
         plot_and_save('correlation.svg', plot_corr_matrix,
                       mat.drop(columns='constant').corr(),
-                      len(events.columns))
+                      len(events['condition'].unique()))
         self._results['correlation_matrix_plot'] = os.path.join(
             runtime.cwd, 'correlation.svg')
 

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -34,6 +34,9 @@ class FirstLevelModelOutputSpec(TraitedSpec):
 
 
 class FirstLevelModel(SimpleInterface):
+    input_spec = FirstLevelModelInputSpec
+    output_spec = FirstLevelModelOutputSpec
+
     def _run_interface(self, runtime):
         info = self.inputs.session_info
 

--- a/fitlins/utils/bids.py
+++ b/fitlins/utils/bids.py
@@ -86,21 +86,17 @@ def collect_participants(bids_dir, participant_label=None, strict=False):
     if not participant_label:
         return all_participants
 
-    if isinstance(participant_label, str):
-        participant_label = [participant_label]
-
     # Drop sub- prefixes
     participant_label = [sub[4:] if sub.startswith('sub-') else sub for sub in participant_label]
-    # Remove duplicates
-    participant_label = sorted(set(participant_label))
-    # Remove labels not found
-    found_label = sorted(set(participant_label) & set(all_participants))
+
+    found_label = layout.get_subjects(subject=participant_label)
+
     if not found_label:
         raise BIDSError('Could not find participants [{}]'.format(
             ', '.join(participant_label)), bids_dir)
 
     # Warn if some IDs were not found
-    notfound_label = sorted(set(participant_label) - set(all_participants))
+    notfound_label = sorted(set(participant_label) - set(found_label))
     if notfound_label:
         exc = BIDSError('Some participants were not found: {}'.format(
             ', '.join(notfound_label)), bids_dir)

--- a/fitlins/utils/bids.py
+++ b/fitlins/utils/bids.py
@@ -14,8 +14,6 @@ Fetch some test data
     >>> os.chdir(data_root)
 
 """
-import os
-import os.path as op
 import warnings
 from bids.grabbids import BIDSLayout
 

--- a/fitlins/workflows/__init__.py
+++ b/fitlins/workflows/__init__.py
@@ -1,0 +1,1 @@
+from .base import init_fitlins_wf

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -41,18 +41,15 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir,
         iterfield=['entities', 'in_file'],
         name='ds_contrasts')
 
-    def _get_ents(session_infos):
-        return [info['entities'] for info in session_infos]
-
     wf.connect([
-        (loader, getter,  [('session_info', 'session_info')]),
+        (loader, getter,  [('entities', 'entities')]),
         (loader, flm, [('session_info', 'session_info'),
                        ('contrast_info', 'contrast_info')]),
         (getter, flm, [('bold_files', 'bold_file'),
                        ('mask_files', 'mask_file')]),
-        (loader, ds_design, [(('session_info', _get_ents), 'entities')]),
-        (loader, ds_corr, [(('session_info', _get_ents), 'entities')]),
-        (loader, ds_contrasts, [(('session_info', _get_ents), 'entities')]),
+        (loader, ds_design, [('entities', 'entities')]),
+        (loader, ds_corr, [('entities', 'entities')]),
+        (loader, ds_contrasts, [('entities', 'entities')]),
         (flm, ds_design, [('design_matrix_plot', 'in_file')]),
         (flm, ds_corr, [('correlation_matrix_plot', 'in_file')]),
         (flm, ds_contrasts, [('contrast_matrix_plot', 'in_file')]),

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -3,7 +3,8 @@ from ..interfaces.bids import LoadLevel1BIDSModel, BIDSSelect, BIDSDataSink
 from ..interfaces.nistats import FirstLevelModel
 
 
-def init_fitlins_wf(bids_dir, preproc_dir, base_dir, name='fitlins_wf'):
+def init_fitlins_wf(bids_dir, preproc_dir, out_dir,
+                    base_dir=None, name='fitlins_wf'):
     wf = pe.Workflow(name=name, base_dir=base_dir)
 
     loader = pe.Node(
@@ -19,15 +20,26 @@ def init_fitlins_wf(bids_dir, preproc_dir, base_dir, name='fitlins_wf'):
         iterfield=['session_info', 'contrast_info', 'bold_file', 'mask_file'],
         name='flm')
 
-    sink_dms = pe.MapNode(
-        BIDSDataSink(
-            base_directory='/work/derivatives/fitlins',
-            fixed_entities={'type': 'design'},
-            path_patterns='sub-{subject}/[ses-{session}/]sub-{subject}_'
-                          '[ses-{session}_]task-{task}_bold_{type<design>}.svg'
-            ),
+    image_pattern = 'sub-{subject}/[ses-{session}/]sub-{subject}_' \
+        '[ses-{session}_]task-{task}_bold_{type<design|corr|contrasts>}.svg'
+    ds_design = pe.MapNode(
+        BIDSDataSink(base_directory=out_dir, fixed_entities={'type': 'design'},
+                     path_patterns=image_pattern),
         iterfield=['entities', 'in_file'],
-        name='sink_dms')
+        name='ds_design')
+
+    ds_corr = pe.MapNode(
+        BIDSDataSink(base_directory=out_dir, fixed_entities={'type': 'corr'},
+                     path_patterns=image_pattern),
+        iterfield=['entities', 'in_file'],
+        name='ds_corr')
+
+    ds_contrasts = pe.MapNode(
+        BIDSDataSink(base_directory=out_dir,
+                     fixed_entities={'type': 'contrasts'},
+                     path_patterns=image_pattern),
+        iterfield=['entities', 'in_file'],
+        name='ds_contrasts')
 
     def _get_ents(session_infos):
         return [info['entities'] for info in session_infos]
@@ -38,8 +50,12 @@ def init_fitlins_wf(bids_dir, preproc_dir, base_dir, name='fitlins_wf'):
                        ('contrast_info', 'contrast_info')]),
         (getter, flm, [('bold_files', 'bold_file'),
                        ('mask_files', 'mask_file')]),
-        (loader, sink_dms, [(('session_info', _get_ents), 'entities')]),
-        (flm, sink_dms, [('design_matrix_plot', 'in_file')]),
+        (loader, ds_design, [(('session_info', _get_ents), 'entities')]),
+        (loader, ds_corr, [(('session_info', _get_ents), 'entities')]),
+        (loader, ds_contrasts, [(('session_info', _get_ents), 'entities')]),
+        (flm, ds_design, [('design_matrix_plot', 'in_file')]),
+        (flm, ds_corr, [('correlation_matrix_plot', 'in_file')]),
+        (flm, ds_contrasts, [('contrast_matrix_plot', 'in_file')]),
         ])
 
     return wf

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -20,6 +20,15 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir,
         iterfield=['session_info', 'contrast_info', 'bold_file', 'mask_file'],
         name='flm')
 
+    contrast_pattern = '[sub-{subject}/][ses-{session}/][sub-{subject}_]' \
+        '[ses-{session}_]task-{task}_bold[_space-{space}]_' \
+        'contrast-{contrast}_{type<stat>}.nii.gz',
+    ds_contrast_maps = pe.MapNode(
+        BIDSDataSink(base_directory=out_dir,
+                     path_patterns=contrast_pattern),
+        iterfield=['fixed_entities', 'entities', 'in_file'],
+        name='ds_contrast_maps')
+
     image_pattern = 'sub-{subject}/[ses-{session}/]sub-{subject}_' \
         '[ses-{session}_]task-{task}_bold_{type<design|corr|contrasts>}.svg'
     ds_design = pe.MapNode(
@@ -47,6 +56,9 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir,
                        ('contrast_info', 'contrast_info')]),
         (getter, flm, [('bold_files', 'bold_file'),
                        ('mask_files', 'mask_file')]),
+        (getter, ds_contrast_maps, [('entities', 'fixed_entities')]),
+        (flm, ds_contrast_maps, [('contrast_maps', 'in_file'),
+                                 ('contrast_metadata', 'entities')]),
         (loader, ds_design, [('entities', 'entities')]),
         (loader, ds_corr, [('entities', 'entities')]),
         (loader, ds_contrasts, [('entities', 'entities')]),

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -3,12 +3,14 @@ from ..interfaces.bids import LoadLevel1BIDSModel, BIDSSelect, BIDSDataSink
 from ..interfaces.nistats import FirstLevelModel
 
 
-def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space, model=None,
+def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space,
+                    model=None, participants='.*',
                     base_dir=None, name='fitlins_wf'):
     wf = pe.Workflow(name=name, base_dir=base_dir)
 
     loader = pe.Node(
-        LoadLevel1BIDSModel(bids_dirs=[bids_dir, preproc_dir]),
+        LoadLevel1BIDSModel(bids_dirs=[bids_dir, preproc_dir],
+                            selectors={'subject': participants}),
         name='loader')
     if model is not None:
         loader.inputs.model = model

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -37,6 +37,20 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space, model=None,
         iterfield=['fixed_entities', 'entities', 'in_file'],
         name='ds_contrast_maps')
 
+    contrast_plot_pattern = '[sub-{subject}/][ses-{session}/][sub-{subject}_]'\
+        '[ses-{session}_]task-{task}_bold[_space-{space}]_' \
+        'contrast-{contrast}_ortho.png',
+    ds_estimate_plots = pe.MapNode(
+        BIDSDataSink(base_directory=out_dir,
+                     path_patterns=contrast_plot_pattern),
+        iterfield=['fixed_entities', 'entities', 'in_file'],
+        name='ds_estimate_plots')
+    ds_contrast_plots = pe.MapNode(
+        BIDSDataSink(base_directory=out_dir,
+                     path_patterns=contrast_plot_pattern),
+        iterfield=['fixed_entities', 'entities', 'in_file'],
+        name='ds_contrast_plots')
+
     image_pattern = 'sub-{subject}/[ses-{session}/]sub-{subject}_' \
         '[ses-{session}_]task-{task}_bold_{type<design|corr|contrasts>}.svg'
     ds_design = pe.MapNode(
@@ -70,6 +84,12 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space, model=None,
                                  ('estimate_metadata', 'entities')]),
         (flm, ds_contrast_maps, [('contrast_maps', 'in_file'),
                                  ('contrast_metadata', 'entities')]),
+        (getter, ds_estimate_plots, [('entities', 'fixed_entities')]),
+        (getter, ds_contrast_plots, [('entities', 'fixed_entities')]),
+        (flm, ds_estimate_plots, [('estimate_map_plots', 'in_file'),
+                                  ('estimate_metadata', 'entities')]),
+        (flm, ds_contrast_plots, [('contrast_map_plots', 'in_file'),
+                                  ('contrast_metadata', 'entities')]),
         (loader, ds_design, [('entities', 'entities')]),
         (loader, ds_corr, [('entities', 'entities')]),
         (loader, ds_contrasts, [('entities', 'entities')]),

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -1,0 +1,45 @@
+from nipype.pipeline import engine as pe
+from ..interfaces.bids import LoadLevel1BIDSModel, BIDSSelect, BIDSDataSink
+from ..interfaces.nistats import FirstLevelModel
+
+
+def init_fitlins_wf(bids_dir, preproc_dir, base_dir, name='fitlins_wf'):
+    wf = pe.Workflow(name=name, base_dir=base_dir)
+
+    loader = pe.Node(
+        LoadLevel1BIDSModel(bids_dirs=[bids_dir, preproc_dir]),
+        name='loader')
+    getter = pe.Node(
+        BIDSSelect(bids_dirs=preproc_dir,
+                   selectors={'type': 'preproc',
+                              'space': 'MNI152NLin2009cAsym'}),
+        name='getter')
+    flm = pe.MapNode(
+        FirstLevelModel(),
+        iterfield=['session_info', 'contrast_info', 'bold_file', 'mask_file'],
+        name='flm')
+
+    sink_dms = pe.MapNode(
+        BIDSDataSink(
+            base_directory='/work/derivatives/fitlins',
+            fixed_entities={'type': 'design'},
+            path_patterns='sub-{subject}/[ses-{session}/]sub-{subject}_'
+                          '[ses-{session}_]task-{task}_bold_{type<design>}.svg'
+            ),
+        iterfield=['entities', 'in_file'],
+        name='sink_dms')
+
+    def _get_ents(session_infos):
+        return [info['entities'] for info in session_infos]
+
+    wf.connect([
+        (loader, getter,  [('session_info', 'session_info')]),
+        (loader, flm, [('session_info', 'session_info'),
+                       ('contrast_info', 'contrast_info')]),
+        (getter, flm, [('bold_files', 'bold_file'),
+                       ('mask_files', 'mask_file')]),
+        (loader, sink_dms, [(('session_info', _get_ents), 'entities')]),
+        (flm, sink_dms, [('design_matrix_plot', 'in_file')]),
+        ])
+
+    return wf

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -23,6 +23,11 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir,
     contrast_pattern = '[sub-{subject}/][ses-{session}/][sub-{subject}_]' \
         '[ses-{session}_]task-{task}_bold[_space-{space}]_' \
         'contrast-{contrast}_{type<stat>}.nii.gz',
+    ds_estimate_maps = pe.MapNode(
+        BIDSDataSink(base_directory=out_dir,
+                     path_patterns=contrast_pattern),
+        iterfield=['fixed_entities', 'entities', 'in_file'],
+        name='ds_estimate_maps')
     ds_contrast_maps = pe.MapNode(
         BIDSDataSink(base_directory=out_dir,
                      path_patterns=contrast_pattern),
@@ -56,7 +61,10 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir,
                        ('contrast_info', 'contrast_info')]),
         (getter, flm, [('bold_files', 'bold_file'),
                        ('mask_files', 'mask_file')]),
+        (getter, ds_estimate_maps, [('entities', 'fixed_entities')]),
         (getter, ds_contrast_maps, [('entities', 'fixed_entities')]),
+        (flm, ds_estimate_maps, [('estimate_maps', 'in_file'),
+                                 ('estimate_metadata', 'entities')]),
         (flm, ds_contrast_maps, [('contrast_maps', 'in_file'),
                                  ('contrast_metadata', 'entities')]),
         (loader, ds_design, [('entities', 'entities')]),

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -3,18 +3,21 @@ from ..interfaces.bids import LoadLevel1BIDSModel, BIDSSelect, BIDSDataSink
 from ..interfaces.nistats import FirstLevelModel
 
 
-def init_fitlins_wf(bids_dir, preproc_dir, out_dir,
+def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space, model=None,
                     base_dir=None, name='fitlins_wf'):
     wf = pe.Workflow(name=name, base_dir=base_dir)
 
     loader = pe.Node(
         LoadLevel1BIDSModel(bids_dirs=[bids_dir, preproc_dir]),
         name='loader')
+    if model is not None:
+        loader.inputs.model = model
+
     getter = pe.Node(
         BIDSSelect(bids_dirs=preproc_dir,
-                   selectors={'type': 'preproc',
-                              'space': 'MNI152NLin2009cAsym'}),
+                   selectors={'type': 'preproc', 'space': space}),
         name='getter')
+
     flm = pe.MapNode(
         FirstLevelModel(),
         iterfield=['session_info', 'contrast_info', 'bold_file', 'mask_file'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ numpy>=1.11
 nilearn>=0.4.0
 pandas>=0.19
 pybids>=0.5.1
+git+https://github.com/grabbles/grabbit.git@3fe38c7e7eb510a38e6c2d072bdc913aaa1b7389#egg=grabbit-0.1.2-dev
 git+https://github.com/nistats/nistats.git@ce3695e8f34c6f34323766dc96a60a53b69d2729#egg=nistats-0.0.1b-dev

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 99
+doctests = True
+exclude=*build/
+per-file-ignores =
+    */__init__.py : F401


### PR DESCRIPTION
This PR tracks progress towards Nipype-ification of FitLins.

I'm starting to settle on an approach that mimics `SpecifyModel` but with a BIDS structure and possible selectors as inputs. The `session_info` objects at present contains sparse and dense components of the design, along with enough metadata to perform file selection (possibly through `BIDSDataGrabber` or a new, similar interface).

It probably makes sense to extend beyond the `SpecifyModel` API further to line up contrasts.

I anticipate the output of this will be shuttled to a `MapNode` to run all first-level estimates and contrasts.

My thoughts on second-level stats are not yet fully fleshed out. I think it would be good to try to head back to pybids and get to the point where we define the design and contrast matrices in such a way as to allow us to run all higher levels in a single shot.

Addresses #12.