### PR TITLE
ENH: Add acq, rec, run and echo to output patterns

### DIFF
--- a/fitlins/base.py
+++ b/fitlins/base.py
@@ -27,14 +27,20 @@ plt.rcParams['svg.fonttype'] = 'none'
 plt.rcParams['image.interpolation'] = 'nearest'
 
 PATH_PATTERNS = (
-    '[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
-    'task-{task}_bold[_space-{space}]_contrast-{contrast}_{type<stat>}.nii.gz',
-    '[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
-    'task-{task}_bold[_space-{space}]_contrast-{contrast}_{type<ortho>}.png',
-    'sub-{subject}/[ses-{session}/]sub-{subject}_[ses-{session}_]'
-    'task-{task}_bold_{type<design>}.tsv',
-    '[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
-    'task-{task}_bold_{type<corr|contrasts>}.svg',
+    ('[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
+     'task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}]'
+     '[_echo-{echo}]_bold[_space-{space}]_contrast-{contrast}_'
+     '{type<stat>}.nii.gz'),
+    ('[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
+     'task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}]'
+     '[_echo-{echo}]_bold[_space-{space}]_contrast-{contrast}_'
+     '{type<ortho>}.png'),
+    ('sub-{subject}/[ses-{session}/]sub-{subject}_[ses-{session}_]'
+     'task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}]'
+     '[_echo-{echo}]_bold_{type<design>}.tsv'),
+    ('[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
+     'task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}]'
+     '[_echo-{echo}]_bold_{type<corr|contrasts>}.svg'),
     )
 
 


### PR DESCRIPTION
The original pattern for functional images is:

```
sub-{subject}[/ses-{session}]/func/
    sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{type<bold>}.nii.gz
```

Any of these may appear in preprocessed files, so we should be prepared to distinguish between their respective outputs.

Fixes #18.