### PR TITLE
Create group level results dir - fix #21

### DIFF
--- a/fitlins/base.py
+++ b/fitlins/base.py
@@ -244,6 +244,8 @@ def second_level(analysis, block, space, deriv_dir):
             deriv_dir,
             fl_layout.build_path(contrasts_ents, strict=True))
 
+        # Make parent results directory
+        os.makedirs(os.path.dirname(contrasts_fname), exist_ok=True)
         plot_and_save(contrasts_fname, plot_contrast_matrix, contrasts,
                       ornt='horizontal')
 


### PR DESCRIPTION
Fix to #21 by creating the parent folder.

There may be a more elegant way to do this rather than just assuming that will be the first time the folder is needed. But for the time being this fixes the bug. 