### PR TITLE
ENH: Make dataset description

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -135,9 +135,7 @@ def create_workflow(opts):
     deriv_dir = op.join(output_dir, 'fitlins')
     os.makedirs(deriv_dir, exist_ok=True)
 
-    desc = op.join(deriv_dir, 'dataset_description.json')
-    with open(desc, 'w') as fobj:
-        json.dump({'Name': 'FitLins output', 'BIDSVersion': '1.1.0'}, fobj)
+    bids.write_derivative_description(bids_dir, deriv_dir)
 
     # BIDS-Apps prefers 'participant', BIDS-Model prefers 'subject'
     level = 'subject' if opts.analysis_level == 'participant' else opts.analysis_level

--- a/fitlins/utils/bids.py
+++ b/fitlins/utils/bids.py
@@ -145,7 +145,6 @@ def write_derivative_description(bids_dir, deriv_dir):
     if 'License' in orig_desc:
         desc['License'] = orig_desc['License']
 
-    os.makedirs(deriv_dir, exist_ok=True)
     with open(os.path.join(deriv_dir, 'dataset_description.json'), 'w') as fobj:
         json.dump(desc, fobj)
 

--- a/fitlins/utils/bids.py
+++ b/fitlins/utils/bids.py
@@ -113,6 +113,8 @@ def write_derivative_description(bids_dir, deriv_dir):
     from fitlins import __version__
 
     desc = {
+        'Name': 'Fitlins output',
+        'BIDSVersion': '1.1.0',
         'PipelineDescription': {
             'Name': 'FitLins',
             'Version': __version__,


### PR DESCRIPTION
Following BEP 003:

> ## Derived dataset and pipeline description
> `<dataset>/derivatives/<pipeline_name>/dataset_description.json`
> 
> Keys:
> * HowToAcknowledge
> * PipelineDescription
>   * Name
>   * Version
>   * CodeURL
>   * DockerHubContainerTag
>   * SingularityContainerURL
>   * SingularityContainerMD5
> * SourceDatasetsURLs - a list of URLs to the source dataset(s) (mandatory)
> * SourceDatasetsVersions - a list of versions of the source dataset(s) (optional only if SourceDatasetsURLs specify the version unequivocally)
> * License

We should start adding docker hub tags and singularity URLs as environment variables when we build images. I've put in a stub to get the MD5, which will attempt to pull the `'version'` tag from Singularity Hub.

BIDS doesn't specify a field for version, which seems like an oversight, but perhaps there's another mechanism for marking it?

Long-term, it would be good to standardize the construction of this metadata in the BIDS-App spec and pybids.

Related to discussion in #28.