### PR TITLE
ENH: Enable derivative label to tag pipelines

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -80,6 +80,8 @@ def get_parser():
                         help='location of BIDS model description (default bids_dir/model.json)')
     g_bids.add_argument('-p', '--preproc-dir', action='store', default=None,
                         help='location of preprocessed data (default bids_dir/fmriprep)')
+    g_bids.add_argument('--derivative-label', action='store', type=str,
+                        help='execution label to append to derivative directory name')
     g_bids.add_argument('--space', action='store',
                         choices=['MNI152NLin2009cAsym'], default='MNI152NLin2009cAsym',
                         help='registered space of input datasets')
@@ -132,7 +134,11 @@ def create_workflow(opts):
     model = default_path(opts.model, bids_dir, 'model.json')
     if opts.model in (None, 'default') and not os.path.exists(model):
         model = 'default'
-    deriv_dir = op.join(output_dir, 'fitlins')
+
+    pipeline_name = 'fitlins'
+    if opts.derivative_label:
+        pipeline_name += '_' + opts.derivative_label
+    deriv_dir = op.join(output_dir, pipeline_name)
     os.makedirs(deriv_dir, exist_ok=True)
 
     bids.write_derivative_description(bids_dir, deriv_dir)


### PR DESCRIPTION
Derivative labels allow for multiple instances of the pipeline to be run with different parameters, identified by a human-readable label. The format is:

```
<outdir>/<pipeline>[_<derivative-label>]
```

In this case, `<pipeline>` is `fitlins`.

This is in accordance with discussions at the 2017 BIDS sprint, followed up by a brief [proposal](https://groups.google.com/d/msg/bids-apps-dev/xjqA_BhivMY/e-YOORvgAgAJ) on the [bids-apps-dev](https://groups.google.com/forum/#!forum/bids-apps-dev) mailing list.