### PR TITLE
RF: Simplify entry-points, restore preproc discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # pull request on our GitHub repository:
 #     https://github.com/kaczmarj/neurodocker
 #
-# Timestamp: 2018-04-18 20:02:44
+# Timestamp: 2018-05-22 20:52:23
 
 FROM neurodebian@sha256:5fbbad8c68525b588a459092254094436aae9dc1f3920f8d871a03053b10377c
 
@@ -84,11 +84,14 @@ RUN conda install -y -q --name neuro numpy=1.14.1 \
                                      seaborn=0.8.1 \
                                      pytables=3.4.2 \
                                      pandas=0.22.0 \
-                                     nipype=1.0.1 \
+                                     nipype=1.0.3 \
                                      patsy \
     && sync && conda clean -tipsy && sync
 
 COPY [".", "/src/fitlins"]
+
+# User-defined instruction
+RUN echo "$VERSION" > /src/fitlins/fitlins/VERSION
 
 USER root
 
@@ -174,7 +177,7 @@ RUN echo '{ \
     \n      "miniconda", \
     \n      { \
     \n        "env_name": "neuro", \
-    \n        "conda_install": "numpy=1.14.1 scipy=1.0.0 scikit-learn=0.19.1 matplotlib=2.1.2 seaborn=0.8.1 pytables=3.4.2 pandas=0.22.0 nipype=1.0.1 patsy" \
+    \n        "conda_install": "numpy=1.14.1 scipy=1.0.0 scikit-learn=0.19.1 matplotlib=2.1.2 seaborn=0.8.1 pytables=3.4.2 pandas=0.22.0 nipype=1.0.3 patsy" \
     \n      } \
     \n    ], \
     \n    [ \
@@ -183,6 +186,10 @@ RUN echo '{ \
     \n        ".", \
     \n        "/src/fitlins" \
     \n      ] \
+    \n    ], \
+    \n    [ \
+    \n      "run", \
+    \n      "echo \"$VERSION\" > /src/fitlins/fitlins/VERSION" \
     \n    ], \
     \n    [ \
     \n      "user", \
@@ -234,6 +241,6 @@ RUN echo '{ \
     \n      } \
     \n    ] \
     \n  ], \
-    \n  "generation_timestamp": "2018-04-18 20:02:44", \
+    \n  "generation_timestamp": "2018-05-22 20:52:23", \
     \n  "neurodocker_version": "0.3.2" \
     \n}' > /neurodocker/neurodocker_specs.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # pull request on our GitHub repository:
 #     https://github.com/kaczmarj/neurodocker
 #
-# Timestamp: 2018-05-22 20:52:23
+# Timestamp: 2018-05-23 00:49:26
 
 FROM neurodebian@sha256:5fbbad8c68525b588a459092254094436aae9dc1f3920f8d871a03053b10377c
 
@@ -90,10 +90,10 @@ RUN conda install -y -q --name neuro numpy=1.14.1 \
 
 COPY [".", "/src/fitlins"]
 
+USER root
+
 # User-defined instruction
 RUN echo "$VERSION" > /src/fitlins/fitlins/VERSION
-
-USER root
 
 # User-defined instruction
 RUN mkdir /work && chown -R neuro /src /work
@@ -188,12 +188,12 @@ RUN echo '{ \
     \n      ] \
     \n    ], \
     \n    [ \
-    \n      "run", \
-    \n      "echo \"$VERSION\" > /src/fitlins/fitlins/VERSION" \
-    \n    ], \
-    \n    [ \
     \n      "user", \
     \n      "root" \
+    \n    ], \
+    \n    [ \
+    \n      "run", \
+    \n      "echo \"$VERSION\" > /src/fitlins/fitlins/VERSION" \
     \n    ], \
     \n    [ \
     \n      "run", \
@@ -241,6 +241,6 @@ RUN echo '{ \
     \n      } \
     \n    ] \
     \n  ], \
-    \n  "generation_timestamp": "2018-05-22 20:52:23", \
+    \n  "generation_timestamp": "2018-05-23 00:49:26", \
     \n  "neurodocker_version": "0.3.2" \
     \n}' > /neurodocker/neurodocker_specs.json

--- a/fitlins/_version.py
+++ b/fitlins/_version.py
@@ -483,6 +483,18 @@ def get_versions():
 
     cfg = get_config()
     verbose = cfg.verbose
+    root_dir = os.path.dirname(__file__)
+    if os.path.isfile(os.path.join(root_dir, 'VERSION')):
+        with open(os.path.join(root_dir, 'VERSION')) as vfile:
+            version = vfile.readline().strip()
+
+        return {
+            "version": version,
+            "full-revisionid": None,
+            "dirty": False,
+            "error": None,
+            "date": None
+            }
 
     try:
         return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -10,7 +10,6 @@ import sys
 import os
 import os.path as op
 import time
-import json
 import logging
 import warnings
 from argparse import ArgumentParser

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -60,10 +60,10 @@ def get_parser():
     # Arguments as specified by BIDS-Apps
     # required, positional arguments
     # IMPORTANT: they must go directly with the parser object
-    parser.add_argument('bids_dir', action='store',
+    parser.add_argument('bids_dir', action='store', type=op.abspath,
                         help='the root folder of a BIDS valid dataset (sub-XXXXX folders should '
                              'be found at the top level in this folder).')
-    parser.add_argument('output_dir', action='store',
+    parser.add_argument('output_dir', action='store', type=op.abspath,
                         help='the output path for the outcomes of preprocessing and visual '
                              'reports')
     parser.add_argument('analysis_level', choices=['run', 'session', 'participant', 'dataset'],
@@ -78,8 +78,9 @@ def get_parser():
                              'removed)')
     g_bids.add_argument('-m', '--model', action='store', default='model.json',
                         help='location of BIDS model description (default bids_dir/model.json)')
-    g_bids.add_argument('-p', '--preproc-dir', action='store', default=None,
-                        help='location of preprocessed data (default bids_dir/fmriprep)')
+    g_bids.add_argument('-p', '--preproc-dir', action='store', default='fmriprep',
+                        help='location of preprocessed data (if relative path, search '
+                             'bids_dir/derivatives, followed by output_dir)')
     g_bids.add_argument('--derivative-label', action='store', type=str,
                         help='execution label to append to derivative directory name')
     g_bids.add_argument('--space', action='store',
@@ -95,7 +96,7 @@ def get_parser():
                          help='run debug version of workflow')
 
     g_other = parser.add_argument_group('Other options')
-    g_other.add_argument('-w', '--work-dir', action='store',
+    g_other.add_argument('-w', '--work-dir', action='store', type=op.abspath,
                          help='path where intermediate results should be stored')
 
     return parser
@@ -114,16 +115,11 @@ def main(args=None):
 def create_workflow(opts):
     """Build workflow"""
 
-    # First check that bids_dir looks like a BIDS folder
-    bids_dir = op.abspath(opts.bids_dir)
-
     if opts.participant_label is not None:
         subject_list = bids.collect_participants(
-            bids_dir, participant_label=opts.participant_label)
+            opts.bids_dir, participant_label=opts.participant_label)
     else:
         subject_list = opts.participant_label
-
-    output_dir = op.abspath(opts.output_dir)
 
     # Build main workflow
     logger.log(25, INIT_MSG(
@@ -131,23 +127,31 @@ def create_workflow(opts):
         subject_list=subject_list)
     )
 
-    model = default_path(opts.model, bids_dir, 'model.json')
-    if opts.model in (None, 'default') and not os.path.exists(model):
+    model = default_path(opts.model, opts.bids_dir, 'model.json')
+    if opts.model in (None, 'default') and not op.exists(model):
         model = 'default'
+
+    preproc_dir = default_path(opts.preproc_dir,
+                               op.join(opts.bids_dir, 'derivatives'),
+                               'fmriprep')
+    if not op.exists(preproc_dir):
+        preproc_dir = default_path(opts.preproc_dir, opts.output_dir, 'fmriprep')
+        if not op.exists(preproc_dir):
+            raise RuntimeError("Preprocessed data could not be found")
 
     pipeline_name = 'fitlins'
     if opts.derivative_label:
         pipeline_name += '_' + opts.derivative_label
-    deriv_dir = op.join(output_dir, pipeline_name)
+    deriv_dir = op.join(opts.output_dir, pipeline_name)
     os.makedirs(deriv_dir, exist_ok=True)
 
-    bids.write_derivative_description(bids_dir, deriv_dir)
+    bids.write_derivative_description(opts.bids_dir, deriv_dir)
 
     # BIDS-Apps prefers 'participant', BIDS-Model prefers 'subject'
     level = 'subject' if opts.analysis_level == 'participant' else opts.analysis_level
 
     fitlins_wf = init_fitlins_wf(
-        bids_dir, opts.preproc_dir, deriv_dir, opts.space, model=model,
+        opts.bids_dir, preproc_dir, deriv_dir, opts.space, model=model,
         participants=subject_list, base_dir=opts.work_dir,
         include_pattern=opts.include, exclude_pattern=opts.exclude
         )
@@ -155,14 +159,14 @@ def create_workflow(opts):
     try:
         fitlins_wf.run(plugin='MultiProc')
         if model != 'default':
-            retcode = run_model(model, opts.space, level, bids_dir, opts.preproc_dir,
+            retcode = run_model(model, opts.space, level, opts.bids_dir, opts.preproc_dir,
                                 deriv_dir)
         else:
             retcode = 0
     except Exception:
         retcode = 1
 
-    layout = gb.BIDSLayout(bids_dir)
+    layout = gb.BIDSLayout(opts.bids_dir)
     models = ba.auto_model(layout) if model == 'default' else [model]
 
     run_context = {'version': __version__,

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -186,7 +186,7 @@ def run_model(model, space, target_level, bids_dir, preproc_dir, deriv_dir):
 
 
 def main():
-    sys.exit(run_fitlins(sys.argv))
+    sys.exit(run_fitlins(sys.argv[1:]))
 
 
 if __name__ == '__main__':

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -102,24 +102,16 @@ def get_parser():
     return parser
 
 
-def main(args=None):
-    """Entry point"""
+def run_fitlins(argv=None):
     warnings.showwarning = _warn_redirect
-    opts = get_parser().parse_args(args)
+    opts = get_parser().parse_args(argv)
     if opts.debug:
         logger.setLevel(logging.DEBUG)
 
-    create_workflow(opts)
-
-
-def create_workflow(opts):
-    """Build workflow"""
-
+    subject_list = None
     if opts.participant_label is not None:
         subject_list = bids.collect_participants(
             opts.bids_dir, participant_label=opts.participant_label)
-    else:
-        subject_list = opts.participant_label
 
     # Build main workflow
     logger.log(25, INIT_MSG(
@@ -179,7 +171,7 @@ def create_workflow(opts):
         report_dicts = parse_directory(deriv_dir, analysis)
         write_report('unknown', report_dicts, run_context, deriv_dir)
 
-    sys.exit(retcode)
+    return retcode
 
 
 def run_model(model, space, target_level, bids_dir, preproc_dir, deriv_dir):
@@ -192,6 +184,10 @@ def run_model(model, space, target_level, bids_dir, preproc_dir, deriv_dir):
             break
 
     return 0
+
+
+def main():
+    sys.exit(run_fitlins(sys.argv))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@
 
 def main():
     """ Install entry-point """
+    import os
     from setuptools import setup, find_packages
+    from inspect import getfile, currentframe
     import versioneer
     from fitlins.__about__ import (
         __packagename__,
@@ -26,12 +28,28 @@ def main():
         EXTRA_REQUIRES,
     )
 
+    pkg_data = {'fitlins': ['data/fitlins.json', 'data/*.tpl']}
+
+    root_dir = os.path.dirname(os.path.abspath(getfile(currentframe())))
+
+    version = None
+    cmdclass = {}
+    if os.path.isfile(os.path.join(root_dir, 'fitlins', 'VERSION')):
+        with open(os.path.join(root_dir, 'fitlins', 'VERSION')) as vfile:
+            version = vfile.readline().strip()
+        pkg_data['fitlins'].insert(0, 'VERSION')
+
+    if version is None:
+        import versioneer
+        version = versioneer.get_version()
+        cmdclass = versioneer.get_cmdclass()
+
     extensions = []
 
     setup(
         name=__packagename__,
-        version=__version__,
-        cmdclass=versioneer.get_cmdclass(),
+        version=version,
+        cmdclass=cmdclass,
         description=__description__,
         long_description=__longdesc__,
         author=__author__,
@@ -48,7 +66,7 @@ def main():
         tests_require=TESTS_REQUIRES,
         extras_require=EXTRA_REQUIRES,
         dependency_links=LINKS_REQUIRES,
-        package_data={'fitlins': ['data/fitlins.json', 'data/*.tpl']},
+        package_data=pkg_data,
         entry_points={'console_scripts': ['fitlins=fitlins.cli.run:main']},
         packages=find_packages(exclude=("tests",)),
         zip_safe=False,


### PR DESCRIPTION
This places `sys.exit` in the `main` entry-point, to reduce the chance of unexpected exits for any external calling code.

This also restores preproc discovery, prioritizing that found in `<bids_dir>/derivatives`.

Other minor simplifications were also applied, such as allowing `argparse` to apply `os.path.abspath` to file inputs.

Closes #32 
Closes #34 