### PR TITLE
Loop over preproc files, instead of raw BOLD files

### DIFF
--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -167,16 +167,18 @@ class LoadLevel1BIDSModel(SimpleInterface):
                 block.model['HRF_variables'], mode='sparse', force=True):
             info = {}
 
-            bold_files = layout.get(type='bold',
+            space = layout.get_spaces(type='preproc')[0]
+            preproc_files = layout.get(type='preproc',
                                     extensions=['.nii', '.nii.gz'],
+                                    space=space,
                                     **ents)
-            if len(bold_files) != 1:
+            if len(preproc_files) != 1:
                 raise ValueError('Too many BOLD files found')
 
-            fname = bold_files[0].filename
+            fname = preproc_files[0].filename
 
             # Required field in seconds
-            TR = layout.get_metadata(fname)['RepetitionTime']
+            TR = layout.get_metadata(fname, type='bold')['RepetitionTime']
             dense_vars = set(block.model['variables']) - set(block.model['HRF_variables'])
 
             _, confounds, _ = block.get_design_matrix(dense_vars,

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -167,11 +167,12 @@ class LoadLevel1BIDSModel(SimpleInterface):
                 block.model['HRF_variables'], mode='sparse', force=True):
             info = {}
 
-            space = layout.get_spaces(type='preproc')[0]
+            space = layout.get_spaces(type='preproc',
+                                      extensions=['.nii', '.nii.gz'])[0]
             preproc_files = layout.get(type='preproc',
-                                    extensions=['.nii', '.nii.gz'],
-                                    space=space,
-                                    **ents)
+                                       extensions=['.nii', '.nii.gz'],
+                                       space=space,
+                                       **ents)
             if len(preproc_files) != 1:
                 raise ValueError('Too many BOLD files found')
 


### PR DESCRIPTION
Currently, we loop over BOLD files to get the TR. This creates an unnecessary dependency on the bold files being there (unless you use datalad), which would be nice to remove. Here, I loop over preproc files instead, and look for a matching sidecar of type='bold'.

This is untested.