### PR TITLE
FIX: Correctly handle missing confounds

### DIFF
--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -97,7 +97,7 @@ class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
 
         events = pd.read_hdf(info['events'], key='events')
 
-        if info['confounds'] is not None:
+        if info['confounds'] is not None and info['confounds'] != 'None':
             confounds = pd.read_hdf(info['confounds'], key='confounds')
             confound_names = confounds.columns.tolist()
             drift_model = None if 'Cosine00' in confound_names else 'cosine'


### PR DESCRIPTION
Looks like the issue is that in the `session_info` dict, `None` value for `confounds` get turned into a string, and thus is not detected as a None. Here I also check against the string "None". 

Perhaps this should be resolved by ensuring the None value stays of that type, but I'm not sure why/how that is happening. I assume its a NiPype issue.

This allowed me to run a model with no confounds successfully. 

Closes #72 