### PR TITLE
[ENH/DOC/BEP002] Collection of changes from a Tour de Fitlins

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -115,6 +115,10 @@ def run_fitlins(argv=None):
 
     subject_list = None
     if opts.participant_label is not None:
+        # Note:  this might not work correctly since no include/exclude etc
+        # options are provided so the BIDSModel created and used within that
+        # function would do different treatment than the one created as a
+        # part of the workflow
         subject_list = bids.collect_participants(
             opts.bids_dir, participant_label=opts.participant_label)
 

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -186,18 +186,23 @@ def run_fitlins(argv=None):
     except Exception:
         retcode = 1
 
-    layout = BIDSLayout(opts.bids_dir)
-    models = auto_model(layout) if model == 'default' else [model]
-
-    run_context = {'version': __version__,
-                   'command': ' '.join(sys.argv),
-                   'timestamp': time.strftime('%Y-%m-%d %H:%M:%S %z'),
-                   }
-
-    for model in models:
-        analysis = Analysis(layout, model=model)
-        report_dicts = parse_directory(deriv_dir, work_dir, analysis)
-        write_report('unknown', report_dicts, run_context, deriv_dir)
+    # TODO: reincarnate. Also see above notes about using a new
+    # BIDSLayout again although all the options (include/exclude/etc)
+    # might be pertinent to it as well.  Ideally may be it could use
+    # a single instance of the BIDSLayout?
+    #
+    # layout = BIDSLayout(opts.bids_dir)
+    # models = auto_model(layout) if model == 'default' else [model]
+    #
+    # run_context = {'version': __version__,
+    #                'command': ' '.join(sys.argv),
+    #                'timestamp': time.strftime('%Y-%m-%d %H:%M:%S %z'),
+    #                }
+    #
+    # for model in models:
+    #     analysis = Analysis(layout, model=model)
+    #     report_dicts = parse_directory(deriv_dir, work_dir, analysis)
+    #     write_report('unknown', report_dicts, run_context, deriv_dir)
 
     return retcode
 

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -299,7 +299,15 @@ class LoadBIDSModel(SimpleInterface):
             info['repetition_time'] = TR
 
             # Transpose so each contrast gets a row of data instead of column
-            contrasts, index, _ = block.get_contrasts(**ents)[0]
+            # TODO: it had [0] on returned value without any checks -- evil!
+            contrasts_rec = block.get_contrasts(**ents)
+            contrasts_weights = contrasts_rec.weights
+            if len(contrasts_weights) != 1:
+                raise ValueError(
+                    "Expected a contrasts DataFrame with 1 row, got: %s"
+                    % str(contrasts_weights)
+                )
+            # contrasts, index, _ = block.get_contrasts(**ents)[0]
 
             contrast_type_map = defaultdict(lambda: 'T')
             contrast_type_map.update({contrast['name']: contrast['type']

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -200,12 +200,23 @@ class LoadBIDSModel(SimpleInterface):
                 block.model['HRF_variables'], mode='sparse', force=True):
             info = {}
 
-            space = analysis.layout.get_spaces(type='preproc',
-                                               extensions=['.nii', '.nii.gz'])[0]
-            preproc_files = analysis.layout.get(type='preproc',
-                                                extensions=['.nii', '.nii.gz'],
-                                                space=space,
-                                                **ents)
+            # In an old BIDS Derivative spec it was _preproc but RC1
+            # has them as _bold.
+            # Ideally the decision should be made based on the
+            kw = dict(
+                datatype='func',
+                suffix='bold',
+                extensions=['.nii', '.nii.gz']
+            )
+            # Problems:
+            #  - chooses first random space (what if there is multiple?)
+            #  - does not reuse **ents for selection of spaces, which
+            #    IMHO (blame yarikoptic) legit to get only the spaces
+            #    specific to the query (e.g. limited to a subject)
+            space = analysis.layout.get_spaces(**kw)[0]
+            kw.update(ents)
+            preproc_files = analysis.layout.get(space=space, **kw)
+
             if len(preproc_files) != 1:
                 raise ValueError('Too many BOLD files found')
 

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -161,7 +161,9 @@ class LoadBIDSModel(SimpleInterface):
 
     def _run_interface(self, runtime):
         import bids
-        bids.config.set_options(loop_preproc=True)
+        # TODO: return back if needed -- disabled since was crashing
+        # things
+        # bids.config.set_options(loop_preproc=True)
         include = self.inputs.include_pattern
         exclude = self.inputs.exclude_pattern
         if not isdefined(include):

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -172,7 +172,20 @@ class LoadBIDSModel(SimpleInterface):
         paths = [(self.inputs.bids_dir, 'bids')]
         if isdefined(self.inputs.preproc_dir):
             paths.append((self.inputs.preproc_dir, ['bids', 'derivatives']))
-        layout = bids.BIDSLayout(paths, include=include, exclude=exclude)
+        # TODO: return back consideration of all those preproc_dir, for
+        # now we will just provide bids_dir path
+        #
+        # Adina&Yarik use case -- input dataset is the "derivative"
+        # dataset, so config should list both "bids" and "derivative".
+        # For now just hardcoded but might need to become a part of the
+        # model specification or cmd invocation?
+        layout = bids.BIDSLayout(
+            self.inputs.bids_dir,
+            config=['bids', 'derivatives'],
+            # This would add consideration of derivatives/ as derivatives
+            # but would crash if derivatives/ is N/A
+            # derivatives=True,
+            include=include, exclude=exclude)
 
         selectors = self.inputs.selectors
 

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -218,7 +218,9 @@ class LoadBIDSModel(SimpleInterface):
             preproc_files = analysis.layout.get(space=space, **kw)
 
             if len(preproc_files) != 1:
-                raise ValueError('Too many BOLD files found')
+                raise ValueError(
+                    'Found %d BOLD files when expected exactly 1: %s'
+                    % (len(preproc_files), preproc_files))
 
             fname = preproc_files[0].filename
 

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -54,7 +54,7 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space, exclude_pattern=None,
     # Select preprocessed BOLD series to analyze
     getter = pe.Node(
         BIDSSelect(bids_dir=bids_dir,
-                   selectors={'type': 'preproc', 'space': space}),
+                   selectors={'type': 'bold', 'space': space}),
         name='getter')
 
     if preproc_dir is not None:


### PR DESCRIPTION
@yarikoptic:  this is a collection of changes some of which could potentially be adopted as is (we tried to make commits atomic), dropped, or just taken as ideas -- we added some comments which could be useful while RFing to support BEP002 model specification and BIDS Derivatives.  

Commits to probably not bother about at all: (we just wanted to have them committed to get "clean")
- TEMP: disabled code pieces which break and we seemed to not need them 5c66b11cbcfa6ecfff40eb223c7fabc7d4d78fb9
- TEMP+BK: attempt to fixup contrasts handling to be used with current pybids which broke API (again) f42fc030532d798f3f327717e1029e91f890c4fb

Our use case:
- TEMP: hardcode + comment on our case where input dataset is the "derivatives" dataset fe5d929d3189f19d4b57d76ed67d5d67761ce07a

To possibly adopt (as is or with changes):
- ENH+BF: make exception message more informative when no BOLD files are found 2ad43f430bb85b71549296c059a9d33efb458e95
- BEP002: use func.*_bold for analysis (not preproc/) + comments on how to improve 546ec0fb36fad09abf7333be4d0eaed2d4fb2872
- DOC: comment about necessity to get cmdline args into BIDSModel while considering participants 2d47264ba610ae44ff42859348366b6d16f144b0
- ENH: --pdb cmdline option to disable multiproc and fire up pdb session upon failed execution 78925838ce6925733b69b2a500d519df96e622d3 -- it somewhat has limited utility since the majority of execution happens in nipype but it helps to debug early failures
