### PR TITLE
FIX: Restore report generation

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -77,8 +77,8 @@ def get_parser():
     g_bids.add_argument('--participant-label', action='store', nargs='+', default=None,
                         help='one or more participant identifiers (the sub- prefix can be '
                              'removed)')
-    g_bids.add_argument('-m', '--model', action='store', default='model.json',
-                        help='location of BIDS model description (default bids_dir/model.json)')
+    g_bids.add_argument('-m', '--model', action='store',
+                        help='location of BIDS model description')
     g_bids.add_argument('-d', '--derivatives', action='store', nargs='+',
                         help='location of derivatives (including preprocessed images).'
                         'If none specified, indexes all derivatives under bids_dir/derivatives.')
@@ -135,7 +135,7 @@ def run_fitlins(argv=None):
         subject_list=subject_list)
     )
 
-    model = default_path(opts.model, opts.bids_dir, 'model.json')
+    model = default_path(opts.model, opts.bids_dir, 'model-default_smdl.json')
     if opts.model in (None, 'default') and not op.exists(model):
         model = 'default'
 

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -232,9 +232,8 @@ class LoadBIDSModel(SimpleInterface):
                 # t/aCompCor
                 # We may want to add criteria to include HPF columns that are not
                 # explicitly listed in the model
-                names = [col for col in dense.columns
-                         if col.startswith('non_steady_state') or
-                         col in step.model['x']]
+                names = step.model['x'].copy()
+                names.extend(col for col in dense.columns if col.startswith('non_steady_state'))
                 dense = dense[names]
 
                 # These confounds are defined pairwise with the current volume

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -232,7 +232,7 @@ class LoadBIDSModel(SimpleInterface):
                 # t/aCompCor
                 # We may want to add criteria to include HPF columns that are not
                 # explicitly listed in the model
-                names = step.model['x'].copy()
+                names = [var for var in step.model['x'] if var in dense.columns]
                 names.extend(col for col in dense.columns if col.startswith('non_steady_state'))
                 dense = dense[names]
 

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -107,7 +107,7 @@ class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
             contrast_maps.append(es_fname)
             contrast_metadata.append(
                 {'contrast': name,
-                 'type': 'effect',
+                 'suffix': 'effect',
                  **out_ents}
                 )
 
@@ -150,7 +150,7 @@ class SecondLevelModel(NistatsBaseInterface, SimpleInterface):
         contrast_metadata = []
 
         entities = self.inputs.contrast_info[0]['entities']  # Same for all
-        out_ents = {'type': 'stat', **entities}
+        out_ents = {'suffix': 'stat', **entities}
 
         # Only keep files which match all entities for contrast
         stat_metadata = _flatten(self.inputs.stat_metadata)

--- a/fitlins/interfaces/visualizations.py
+++ b/fitlins/interfaces/visualizations.py
@@ -75,6 +75,7 @@ class DesignCorrelationPlot(Visualization):
 
 
 class ContrastMatrixPlotInputSpec(VisualizationInputSpec):
+    contrast_info = traits.List(traits.Dict)
     orientation = traits.Enum('horizontal', 'vertical', usedefault=True,
                               desc='Display orientation of contrast matrix')
 
@@ -83,9 +84,12 @@ class ContrastMatrixPlot(Visualization):
     input_spec = ContrastMatrixPlotInputSpec
 
     def _visualize(self, data, out_name):
-        if 'constant' in data.index:
-            data = data.drop(index='constant')
-        plot_and_save(out_name, plot_contrast_matrix, data,
+        contrast_matrix = pd.DataFrame({c['name']: c['weights'][0]
+                                        for c in self.inputs.contrast_info},
+                                       index=data.columns)
+        if 'constant' in contrast_matrix.index:
+            contrast_matrix = contrast_matrix.drop(index='constant')
+        plot_and_save(out_name, plot_contrast_matrix, contrast_matrix,
                       ornt=self.inputs.orientation)
 
 

--- a/fitlins/interfaces/visualizations.py
+++ b/fitlins/interfaces/visualizations.py
@@ -61,17 +61,24 @@ class DesignPlot(Visualization):
 
 
 class DesignCorrelationPlotInputSpec(VisualizationInputSpec):
-    explanatory_variables = traits.Range(
-        low=0, desc='Number of explanatory variables')
+    contrast_info = traits.List(traits.Dict)
 
 
 class DesignCorrelationPlot(Visualization):
     input_spec = DesignCorrelationPlotInputSpec
 
     def _visualize(self, data, out_name):
+        contrast_matrix = pd.DataFrame({c['name']: c['weights'][0]
+                                        for c in self.inputs.contrast_info})
+        all_cols = list(data.columns)
+        evs = set(contrast_matrix.index)
+        if set(contrast_matrix.index) != all_cols[:len(evs)]:
+            ev_cols = [col for col in all_cols if col in evs]
+            confound_cols = [col for col in all_cols if col not in evs]
+            data = data[ev_cols + confound_cols]
         plot_and_save(out_name, plot_corr_matrix,
                       data.drop(columns='constant').corr(),
-                      self.inputs.explanatory_variables)
+                      len(evs))
 
 
 class ContrastMatrixPlotInputSpec(VisualizationInputSpec):

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -37,7 +37,7 @@ def parse_directory(deriv_dir, work_dir, analysis):
     wd_layout = BIDSLayout(
         str(Path(work_dir) / 'reportlets' / 'fitlins'),
         validate=False)
-    contrast_svgs = fl_layout.get(extensions='.svg', type='contrasts')
+    contrast_svgs = fl_layout.get(extensions='.svg', suffix='contrasts')
 
     analyses = []
     for contrast_svg in contrast_svgs:

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -8,7 +8,7 @@ from ..utils import snake_to_camel
 
 PATH_PATTERNS = [
     '[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
-    'model-{model}.html'
+    'model-{model}[_run-{run}].html'
 ]
 
 add_config_paths(fitlins=pkgr.resource_filename('fitlins', 'data/fitlins.json'))
@@ -41,36 +41,36 @@ def parse_directory(deriv_dir, work_dir, analysis):
 
     analyses = []
     for contrast_svg in contrast_svgs:
-        ents = fl_layout.parse_file_entities(contrast_svg.filename)
-        ents.pop('type')
+        ents = contrast_svg.entities
+        ents.pop('suffix')
         ents.setdefault('subject', None)
-        correlation_matrix = fl_layout.get(extensions='.svg', type='corr',
+        correlation_matrix = fl_layout.get(extensions='.svg', suffix='corr',
                                            **ents)
-        design_matrix = fl_layout.get(extensions='.svg', type='design', **ents)
+        design_matrix = fl_layout.get(extensions='.svg', suffix='design', **ents)
         job_desc = {
             'ents': {k: v for k, v in ents.items() if v is not None},
             'dataset': analysis.layout.root,
             'model_name': analysis.model['name'],
-            'contrasts_svg': contrast_svg.filename,
+            'contrasts_svg': contrast_svg.path,
             }
         if ents.get('subject'):
             job_desc['subject_id'] = ents.get('subject')
         if correlation_matrix:
-            job_desc['correlation_matrix_svg'] = correlation_matrix[0].filename
+            job_desc['correlation_matrix_svg'] = correlation_matrix[0].path
         if design_matrix:
-            job_desc['design_matrix_svg'] = design_matrix[0].filename
+            job_desc['design_matrix_svg'] = design_matrix[0].path
 
-        snippet = wd_layout.get(extensions='.html', type='snippet', **ents)
+        snippet = wd_layout.get(extensions='.html', suffix='snippet', **ents)
         if snippet:
-            with open(snippet[0].filename) as fobj:
+            with open(snippet[0].path) as fobj:
                 job_desc['warning'] = fobj.read()
 
-        contrasts = fl_layout.get(extensions='.png', type='ortho', **ents)
+        contrasts = fl_layout.get(extensions='.png', suffix='ortho', **ents)
         # TODO: Split contrasts from estimates
-        job_desc['contrasts'] = [{'image_file': c.filename,
+        job_desc['contrasts'] = [{'image_file': c.path,
                                   'name':
                                       fl_layout.parse_file_entities(
-                                          c.filename)['contrast']}
+                                          c.path)['contrast']}
                                  for c in contrasts]
         analyses.append(job_desc)
 

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -134,7 +134,8 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
         (l1_model, plot_design, [('design_matrix', 'data')]),
         ])
 
-    stage = []
+    stage = None
+    model = l1_model
     for ix, step in enumerate(step['Level'] for step in model_dict['Steps']):
         # Set up elements common across levels
 
@@ -189,7 +190,6 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
             name='ds_{}_contrast_plots'.format(level))
 
         if ix == 0:
-            model = l1_model
             wf.connect([
                 (loader, select_entities, [('entities', 'inlist')]),
                 (select_entities, getter,  [('out', 'entities')]),
@@ -214,8 +214,8 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
                 name='{}_model'.format(level))
 
             wf.connect([
-                (stage[-1], model, [('contrast_maps', 'stat_files'),
-                                    ('contrast_metadata', 'stat_metadata')]),
+                (stage, model, [('contrast_maps', 'stat_files'),
+                                ('contrast_metadata', 'stat_metadata')]),
             ])
 
         wf.connect([
@@ -231,6 +231,6 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
 
             ])
 
-        stage.append(model)
+        stage = model
 
     return wf

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -71,7 +71,7 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
     image_pattern = '[sub-{subject}/][ses-{session}/]' \
         '[sub-{subject}_][ses-{session}_]task-{task}[_acq-{acquisition}]' \
         '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_bold_' \
-        '{type<design|corr|contrasts>}.svg'
+        '{suffix<design|corr|contrasts>}.svg'
     contrast_plot_pattern = '[sub-{subject}/][ses-{session}/]' \
         '[sub-{subject}_][ses-{session}_]task-{task}[_acq-{acquisition}]' \
         '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_bold' \
@@ -79,7 +79,7 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
     contrast_pattern = '[sub-{subject}/][ses-{session}/]' \
         '[sub-{subject}_][ses-{session}_]task-{task}[_acq-{acquisition}]' \
         '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_bold' \
-        '[_space-{space}]_contrast-{contrast}_{type<effect|stat>}.nii.gz'
+        '[_space-{space}]_contrast-{contrast}_{suffix<effect|stat>}.nii.gz'
 
     # Set up general interfaces
     #
@@ -104,7 +104,7 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
         name='plot_design')
 
     ds_design = pe.MapNode(
-        BIDSDataSink(base_directory=out_dir, fixed_entities={'type': 'design'},
+        BIDSDataSink(base_directory=out_dir, fixed_entities={'suffix': 'design'},
                      path_patterns=image_pattern),
         iterfield=['entities', 'in_file'],
         run_without_submitting=True,


### PR DESCRIPTION
This PR has as its goal restoring report generation, and any stylistic/UX fixes that seem appropriate as I work toward that goal.

Currently reports are based on the presence of contrast matrix plots, which were removed in #84, so no reports are generated. Additional concerns:

* [x] Design matrices produced with columns in alphabetical order - change to `spec['Model']['X']` order.
* [x] Restore design matrix correlation plots