### PR TITLE
BF: allow for legit derivatives boolean value in a neuroscout ad-hoc …

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -141,7 +141,10 @@ def run_fitlins(argv=None):
 
     derivatives = True if not opts.derivatives else opts.derivatives
     # Need this when specifying args directly (i.e. neuroscout)
-    if len(derivatives) == 1:
+    # god bless neuroscout, but let's make it work for others!
+    if isinstance(derivatives, list) and len(derivatives) == 1:
+        # WRONG AND EVIL to those who have spaces in their paths... bad bad practice
+        # TODO - fix neuroscout
         derivatives = derivatives[0].split(" ")
 
     pipeline_name = 'fitlins'


### PR DESCRIPTION
…handling of lists.

Previously, my command failed with `TypeError: object of type 'bool' has no len()` when I did not specify any -d command line argument. 
(Comments are @yarikoptics, please be mad at him for them)