### PR TITLE
BF: Include desc argument in selectors, remove deprecated 'type' key

### DIFF
--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -48,7 +48,9 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
         BIDSSelect(
             bids_dir=bids_dir, derivatives=derivatives,
             selectors={
-                'type': 'preproc', 'suffix': 'bold', 'space': space}),
+                'suffix': 'bold',
+                'desc': desc,
+                'space': space}),
         name='getter')
 
     l1_model = pe.MapNode(


### PR DESCRIPTION
I ran into a failure due to the deprecation of the "type" keyword. Instead, keyword 'desc' is used in a non-hardcoded fashion. A separate PR contains an additional desc argparse argument with 'preproc' as the default value.
