### PR TITLE
BF: Allow for no space in the filename, complain if multiple spaces are found

### DIFF
--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -203,8 +203,20 @@ class LoadBIDSModel(SimpleInterface):
                 space = ents.pop('space')
             else:
                 # Picks first match
-                space = analysis.layout.get_spaces(suffix='bold',
-                                                   extensions=['.nii', '.nii.gz'])[0]
+                spaces = set(
+                    analysis.layout.get_spaces(suffix='bold',
+                                               extensions=['.nii', '.nii.gz'])
+                )
+                if spaces:
+                    spaces = sorted(list(spaces))
+                    space = spaces[0]
+                    if len(spaces) > 1:
+                        iflogger.warning(
+                            'No space was provided, but multiple spaces were detected: %s. '
+                            '"Randomly" choosing the first one in alphabetical order: %s'
+                            % (', '.join(spaces), space))
+                else:
+                    space = None
             preproc_files = analysis.layout.get(suffix='bold',
                                                 extensions=['.nii', '.nii.gz'],
                                                 space=space,


### PR DESCRIPTION
I ran into an error when my repositories files did not contain the space in their name. I don't think it is necessary to have the space keyword to be compulsory. This PR gives an additional option for no specification of space, and will give a warning if several spaces are found. 