### PR TITLE
MNT: Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ USER neuro
 # Update conda environment
 #-------------------------
 RUN /bin/bash -c "source activate neuro \
-      && pip install -q --no-cache-dir --upgrade pip \
+      && pip install --no-cache-dir --upgrade 'pip<19' \
       && pip install -q --no-cache-dir --upgrade -r /src/fitlins/requirements.txt" \
     && sync
 

--- a/fitlins/__about__.py
+++ b/fitlins/__about__.py
@@ -41,13 +41,13 @@ REQUIRES = [
     'pandas>=0.19',
     'tables>=3.2.1',
     'nistats>=0.0.1b0',
-    'pybids>=0.6.5',
+    'pybids>=0.7',
     'jinja2',
 ]
 
 LINKS_REQUIRES = [
     'git+https://github.com/bids-standard/pybids.git@'
-    '36853b0bf222d3174ae7d9d1d9c7a7ecf5049cdd#egg=pybids',
+    'a4bbc811e67df8ffbc186cca4c3c61e0992af09f#egg=pybids',
 ]
 
 TESTS_REQUIRES = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ nilearn>=0.4.0
 pandas>=0.19
 nipype>=1.1.6
 git+https://github.com/nistats/nistats.git@009ce3fddb3dd01e82bca3ad7d2cdbeece0138f2#egg=nistats
-git+https://github.com/bids-standard/pybids.git@36853b0bf222d3174ae7d9d1d9c7a7ecf5049cdd#egg=pybids
+git+https://github.com/bids-standard/pybids.git@a4bbc811e67df8ffbc186cca4c3c61e0992af09f#egg=pybids


### PR DESCRIPTION
Update to post-0.7 pybids (use master to get grabbit 0.2.6 dependency). Also, constrain `pip<19` to avoid pypa/pip#6158.