### PR TITLE
FIX: tiny typo

### DIFF
--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -59,7 +59,7 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, space, desc=None,
     if smoothing:
         smoothing_params = smoothing.split(':', 1)
         if smoothing_params[0] != 'iso':
-            raise ValueError(f"Unknown smoothing type {smoothing_params[0]}")
+            raise ValueError("Unknown smoothing type {smoothing_params[0]}")
         smoother = pe.MapNode(
             fsl.IsotropicSmooth(fwhm=int(smoothing_params[1])),
             iterfield=['in_file'],


### PR DESCRIPTION
I believe this is a typo. Led to

```python

Traceback (most recent call last):
  File "/home/adina/env/fitlins/bin/fitlins", line 11, in <module>
    load_entry_point('fitlins', 'console_scripts', 'fitlins')()
  File "/home/adina/env/fitlins/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 484, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/adina/env/fitlins/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2725, in load_entry_point
    return ep.load()
  File "/home/adina/env/fitlins/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2343, in load
    return self.resolve()
  File "/home/adina/env/fitlins/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2349, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/adina/Repos/fitlins/fitlins/cli/run.py", line 24, in <module>
    from ..workflows import init_fitlins_wf
  File "/home/adina/Repos/fitlins/fitlins/workflows/__init__.py", line 1, in <module>
    from .base import init_fitlins_wf
  File "/home/adina/Repos/fitlins/fitlins/workflows/base.py", line 62
    raise ValueError(f"Unknown smoothing type {smoothing_params[0]}")
                                                                   ^
SyntaxError: invalid syntax
```