### PR TITLE
FIX: Restore level 2+ reports

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -200,7 +200,7 @@ def run_fitlins(argv=None):
     for model in models:
         analysis = Analysis(layout, model=model)
         report_dicts = parse_directory(deriv_dir, work_dir, analysis)
-        write_report('unknown', report_dicts, run_context, deriv_dir)
+        write_report(report_dicts, run_context, deriv_dir)
 
     return retcode
 

--- a/fitlins/data/report.tpl
+++ b/fitlins/data/report.tpl
@@ -26,20 +26,24 @@
             <li>Model: {{ model_name }}</li>
         </ul>
     </div>
+    {% if warning or design_matrix_svg or contrasts_svg or correlation_matrix_svg %}
     <div id="model">
         <h1 class="sub-report-title">Model</h1>
         {{ warning }}
         {% if design_matrix_svg %}
-        <h2>Design matrix</h3>
+        <h2>Design matrix</h2>
         <img src="{{ design_matrix_svg }}" />
         {% endif %}
-        <h2>Contrasts</h3>
+        {% if contrasts_svg %}
+        <h2>Contrasts</h2>
         <img src="{{ contrasts_svg }}" />
+        {% endif %}
         {% if correlation_matrix_svg %}
-        <h2>Correlation matrix</h3>
+        <h2>Correlation matrix</h2>
         <img src="{{ correlation_matrix_svg }}" />
         {% endif %}
     </div>
+    {% endif %}
     {% if contrasts %}
     <div id="contrasts">
         <h1 class="sub-report-title">Contrasts</h1>

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -66,6 +66,14 @@ def parse_directory(deriv_dir, work_dir, analysis):
             job_desc['correlation_matrix_svg'] = correlation_matrix[0].path
         if design_matrix:
             job_desc['design_matrix_svg'] = design_matrix[0].path
+        if ents['run'] is not None:
+            job_desc['level'] = 'run'
+        elif ents['session'] is not None:
+            job_desc['level'] = 'session'
+        elif ents['subject'] is not None:
+            job_desc['level'] = 'subject'
+        else:
+            job_desc['level'] = 'dataset'
 
         snippet = wd_layout.get(extensions='.html', suffix='snippet', **ents)
         if snippet:
@@ -84,7 +92,7 @@ def parse_directory(deriv_dir, work_dir, analysis):
     return analyses
 
 
-def write_report(level, report_dicts, run_context, deriv_dir):
+def write_report(report_dicts, run_context, deriv_dir):
     fl_layout = BIDSLayout(
         deriv_dir, config=['bids', 'derivatives', 'fitlins'])
 
@@ -98,7 +106,7 @@ def write_report(level, report_dicts, run_context, deriv_dir):
         ents = context['ents'].copy()
         ents['model'] = snake_to_camel(context['model_name'])
         target_file = op.join(deriv_dir, fl_layout.build_path(ents, PATH_PATTERNS))
-        html = tpl.render(deroot({'level': level, **context, **run_context},
+        html = tpl.render(deroot({**context, **run_context},
                                  op.dirname(target_file)))
         with open(target_file, 'w') as fobj:
             fobj.write(html)

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -7,8 +7,8 @@ from bids.layout import add_config_paths, BIDSLayout
 from ..utils import snake_to_camel
 
 PATH_PATTERNS = [
-    '[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
-    'model-{model}[_run-{run}].html'
+    'reports/[sub-{subject}/][ses-{session}/][sub-{subject}_][ses-{session}_]'
+    '[run-{run}_]model-{model}.html'
 ]
 
 add_config_paths(fitlins=pkgr.resource_filename('fitlins', 'data/fitlins.json'))

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -47,6 +47,8 @@ def parse_directory(deriv_dir, work_dir, analysis):
     for figdir, ent_tuple in fig_dirs:
         ents = dict(ent_tuple)
         ents.setdefault('subject', None)
+        ents.setdefault('session', None)
+        ents.setdefault('run', None)
         contrast_matrix = fl_layout.get(extensions='.svg', suffix='contrasts', **ents)
         correlation_matrix = fl_layout.get(extensions='.svg', suffix='corr',
                                            **ents)

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -70,11 +70,11 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
         l1_model.inputs.smoothing_fwhm = smoothing_fwhm
 
     # Set up common patterns
-    image_pattern = '[sub-{subject}/][ses-{session}/]' \
+    image_pattern = '[sub-{subject}/][ses-{session}/]figures/[run-{run}/]' \
         '[sub-{subject}_][ses-{session}_]task-{task}[_acq-{acquisition}]' \
         '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_bold_' \
         '{suffix<design|corr|contrasts>}.svg'
-    contrast_plot_pattern = '[sub-{subject}/][ses-{session}/]' \
+    contrast_plot_pattern = '[sub-{subject}/][ses-{session}/]figures/[run-{run}/]' \
         '[sub-{subject}_][ses-{session}_]task-{task}[_acq-{acquisition}]' \
         '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_bold' \
         '[_space-{space}]_contrast-{contrast}_ortho.png'

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -70,18 +70,18 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
         l1_model.inputs.smoothing_fwhm = smoothing_fwhm
 
     # Set up common patterns
-    image_pattern = '[sub-{subject}/][ses-{session}/]figures/[run-{run}/]' \
+    image_pattern = 'reports/[sub-{subject}/][ses-{session}/]figures/[run-{run}/]' \
         '[sub-{subject}_][ses-{session}_]task-{task}[_acq-{acquisition}]' \
-        '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_bold_' \
+        '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_' \
         '{suffix<design|corr|contrasts>}.svg'
-    contrast_plot_pattern = '[sub-{subject}/][ses-{session}/]figures/[run-{run}/]' \
+    contrast_plot_pattern = 'reports/[sub-{subject}/][ses-{session}/]figures/[run-{run}/]' \
         '[sub-{subject}_][ses-{session}_]task-{task}[_acq-{acquisition}]' \
-        '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_bold' \
-        '[_space-{space}]_contrast-{contrast}_ortho.png'
+        '[_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}]_' \
+        'contrast-{contrast}_ortho.png'
     contrast_pattern = '[sub-{subject}/][ses-{session}/]' \
         '[sub-{subject}_][ses-{session}_]task-{task}[_acq-{acquisition}]' \
-        '[_rec-{reconstruction}][_run-{run}][_echo-{echo}]_bold' \
-        '[_space-{space}]_contrast-{contrast}_{suffix<effect|stat>}.nii.gz'
+        '[_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}]_' \
+        'contrast-{contrast}_{suffix<effect|stat>}.nii.gz'
 
     # Set up general interfaces
     #


### PR DESCRIPTION
Beginning work on #90.

First step is creating a figures folder that can be parameterized by run, session or subject. This reduces the clutter of keeping figures and statistical maps together, and also provides a filesystem object (the `figures/` directory) that should one-to-one match with report files that need generating.