### PR TITLE
ENH: Drop missing model inputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+0.5.1 (September 23, 2019)
+==========================
+
+Bug fix release to work with PyBIDS 0.9.4+.
+
+* FIX: Expand entity whitelist (https://github.com/poldracklab/fitlins/pull/182)
+* FIX: Don't validate generated paths (https://github.com/poldracklab/fitlins/pull/180)
+
+
 0.5.0 (July 03, 2019)
 =====================
 

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -181,7 +181,7 @@ def run_fitlins(argv=None):
         space=opts.space, desc=opts.desc_label,
         participants=subject_list, base_dir=work_dir,
         force_index=opts.force_index, ignore=opts.ignore,
-        smoothing=opts.smoothing, drop_missing=opts.drop_missing
+        smoothing=opts.smoothing, drop_missing=opts.drop_missing,
         )
 
     if opts.work_dir:

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -115,7 +115,8 @@ def get_parser():
     g_other = parser.add_argument_group('Other options')
     g_other.add_argument('-w', '--work-dir', action='store', type=op.abspath,
                          help='path where intermediate results should be stored')
-
+    g_other.add_argument('--drop-missing', action='store_true', default=False,
+                         help='drop missing inputs/contrasts in model fitting.')
     return parser
 
 
@@ -180,7 +181,7 @@ def run_fitlins(argv=None):
         space=opts.space, desc=opts.desc_label,
         participants=subject_list, base_dir=work_dir,
         force_index=opts.force_index, ignore=opts.ignore,
-        smoothing=opts.smoothing,
+        smoothing=opts.smoothing, drop_missing=opts.drop_missing
         )
 
     if opts.work_dir:

--- a/fitlins/data/full_report.tpl
+++ b/fitlins/data/full_report.tpl
@@ -102,7 +102,7 @@ summary.heading-2 {
         {% for contrast in analysis.contrasts %}
         <h4>{{ contrast.name }}</h4>
         {% if contrast.glassbrain is none %}
-        <p> Missing contrast skipped (used: --drop-missing) </p>
+        <p> Missing contrast skipped (used: <code>--drop-missing</code>) </p>
         {% else %}
         <img src="{{ contrast.glassbrain }}" />
         {% endif %}

--- a/fitlins/data/full_report.tpl
+++ b/fitlins/data/full_report.tpl
@@ -101,7 +101,11 @@ summary.heading-2 {
         <h3>{{ analysis.entities.items()|map('join', ': ')|map('capitalize')|join(', ') }}</h3>
         {% for contrast in analysis.contrasts %}
         <h4>{{ contrast.name }}</h4>
+        {% if contrast.glassbrain is none %}
+        <p> Missing contrast skipped (used: --drop-missing) </p>
+        {% else %}
         <img src="{{ contrast.glassbrain }}" />
+        {% endif %}
         {% endfor %}
         {% endfor %}
         {% endfor %}

--- a/fitlins/interfaces/abstract.py
+++ b/fitlins/interfaces/abstract.py
@@ -14,6 +14,8 @@ from nipype.interfaces.base import BaseInterface, TraitedSpec, File, traits
 class DesignMatrixInputSpec(TraitedSpec):
     bold_file = File(exists=True, mandatory=True)
     session_info = traits.Dict()
+    drop_missing = traits.Bool(
+            desc='Drop columns in design matrix with all missing values')
 
 
 class DesignMatrixOutputSpec(TraitedSpec):

--- a/fitlins/interfaces/abstract.py
+++ b/fitlins/interfaces/abstract.py
@@ -14,8 +14,6 @@ from nipype.interfaces.base import BaseInterface, TraitedSpec, File, traits
 class DesignMatrixInputSpec(TraitedSpec):
     bold_file = File(exists=True, mandatory=True)
     session_info = traits.Dict()
-    drop_missing = traits.Bool(
-        desc='Drop columns in design matrix with all missing values')
 
 
 class DesignMatrixOutputSpec(TraitedSpec):

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -326,10 +326,6 @@ class LoadBIDSModel(SimpleInterface):
                         dense[imputable][0] = np.nanmean(vals[vals != 0])
                         imputed.append(imputable)
 
-                if np.isnan(dense.values).any():
-                    iflogger.warning('Unexpected NaNs found in design matrix; '
-                                     'regression may fail.')
-
                 dense_file = step_subdir / '{}_dense.h5'.format(ent_string)
                 dense.to_hdf(dense_file, key='dense')
 

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -413,7 +413,8 @@ class BIDSSelect(SimpleInterface):
         mask_files = []
         entities = []
         for ents in self.inputs.entities:
-            bold_file = layout.get(**self.inputs.selectors, **ents)
+            selectors = {**self.inputs.selectors, **ents}
+            bold_file = layout.get(selectors)
 
             if len(bold_file) == 0:
                 raise FileNotFoundError(

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -149,9 +149,7 @@ class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
 
             # If contrast is not computable (i.e. column was dropped)
             if weights is None:
-                for map_list in [effect_maps, variance_maps, zscore_maps,
-                                 pvalue_maps, stat_maps]:
-                    map_list.append(None)
+                continue
             else:
                 maps = flm.compute_contrast(
                     weights, contrast_type, output_type='all')
@@ -242,8 +240,6 @@ class SecondLevelModel(NistatsBaseInterface, SimpleInterface):
         filtered_variances = []
         names = []
         for m, eff, var in zip(stat_metadata, input_effects, input_variances):
-            if not drop_missing and eff is not None: ## Add flag
-                raise RuntimeError('Missing input')
             if _match(out_ents, m):
                 filtered_effects.append(eff)
                 filtered_variances.append(var)

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -40,16 +40,14 @@ def prepare_contrasts(contrasts, all_regressors):
 
 class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface):
 
-    def __init__(self, drop_missing=False):
-        super(DesignMatrix, self).__init__()
-        self._drop_missing = drop_missing
-
     def _run_interface(self, runtime):
         import nibabel as nb
         from nistats import design_matrix as dm
         info = self.inputs.session_info
         img = nb.load(self.inputs.bold_file)
         vols = img.shape[3]
+
+        drop_missing = bool(self.inputs.drop_missing)
 
         if info['sparse'] not in (None, 'None'):
             sparse = pd.read_hdf(info['sparse'], key='sparse').rename(
@@ -63,9 +61,9 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
             dense = pd.read_hdf(info['dense'], key='dense')
 
             missing_columns = dense.isna().all()
-            if self._drop_missing:
+            if drop_missing:
                 # Remove columns with NaNs
-                dense = dense[dense.columns[missing_columns is False]]
+                dense = dense[dense.columns[missing_columns == False]]
             elif missing_columns.any():
                     missing_names = ', '.join(
                         dense.columns[missing_columns].tolist())

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -66,8 +66,7 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
             if self._drop_missing:
                 # Remove columns with NaNs
                 dense = dense[dense.columns[missing_columns is False]]
-            else:
-                if missing_columns.any():
+            elif missing_columns.any():
                     missing_names = ', '.join(
                         dense.columns[missing_columns].tolist())
                     raise RuntimeError(

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -39,13 +39,15 @@ def prepare_contrasts(contrasts, all_regressors):
 
 
 class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface):
+
+    def __init__(self, drop_missing=False):
+        super(DesignMatrix, self).__init__()
+        self._drop_missing = drop_missing
+
     def _run_interface(self, runtime):
         import nibabel as nb
         from nistats import design_matrix as dm
         info = self.inputs.session_info
-        drop_missing = self.inputs.drop_missing
-        if not isdefined(drop_missing):
-            drop_missing = False
         img = nb.load(self.inputs.bold_file)
         vols = img.shape[3]
 
@@ -61,7 +63,7 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
             dense = pd.read_hdf(info['dense'], key='dense')
 
             missing_columns = dense.isna().all()
-            if drop_missing:
+            if self._drop_missing:
                 # Remove columns with NaNs
                 dense = dense[dense.columns[missing_columns is False]]
             else:

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -244,25 +244,39 @@ class SecondLevelModel(NistatsBaseInterface, SimpleInterface):
             weights = weights[0]
             effects = (np.array(filtered_effects)[weights != 0]).tolist()
             _variances = (np.array(filtered_variances)[weights != 0]).tolist()
-            design_matrix = pd.DataFrame({'intercept': weights[weights != 0]})
 
-            model.fit(effects, design_matrix=design_matrix)
-
-            maps = model.compute_contrast(second_level_stat_type=contrast_type,
-                                          output_type='all')
             contrast_metadata.append(
                 {'contrast': name,
                  'stat': contrast_type,
                  **out_ents})
 
-            for map_type, map_list in (('effect_size', effect_maps),
-                                       ('effect_variance', variance_maps),
-                                       ('z_score', zscore_maps),
-                                       ('p_value', pvalue_maps),
-                                       ('stat', stat_maps)):
-                fname = fname_fmt(name, map_type)
-                maps[map_type].to_filename(fname)
-                map_list.append(fname)
+            if len(effects) == 1:
+                print("Passing through results from previous model,"
+                      "as only one is available")
+                effect_maps.append(effects[0])
+                variance_maps.append(_variances[0])
+                zscore_maps.append()
+                pvalue_maps.append()
+                stat_maps.append()
+            else:
+                design_matrix = pd.DataFrame(
+                    {'intercept': weights[weights != 0]})
+
+                model.fit(effects, design_matrix=design_matrix)
+
+                maps = model.compute_contrast(
+                    second_level_stat_type=contrast_type,
+                    output_type='all')
+
+
+                for map_type, map_list in (('effect_size', effect_maps),
+                                           ('effect_variance', variance_maps),
+                                           ('z_score', zscore_maps),
+                                           ('p_value', pvalue_maps),
+                                           ('stat', stat_maps)):
+                    fname = fname_fmt(name, map_type)
+                    maps[map_type].to_filename(fname)
+                    map_list.append(fname)
 
         self._results['effect_maps'] = effect_maps
         self._results['variance_maps'] = variance_maps

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -94,7 +94,7 @@ class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
                     missing_names = ', '.join(
                         dense.columns[missing_columns].tolist())
                     raise RuntimeError(
-                        f'The following columns are empty: {missing_names}.'
+                        f'The following columns are empty: {missing_names}. '
                         'Use --drop-missing to drop before model fitting.')
 
             column_names = dense.columns.tolist()
@@ -141,16 +141,15 @@ class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
         fname_fmt = os.path.join(runtime.cwd, '{}_{}.nii.gz').format
         for name, weights, contrast_type in prepare_contrasts(
                 self.inputs.contrast_info, mat.columns.tolist()):
-            contrast_metadata.append(
-                {'contrast': name,
-                 'stat': contrast_type,
-                 **out_ents}
-                )
-
             # If contrast is not computable (i.e. column was dropped)
             if weights is None:
                 continue
             else:
+                contrast_metadata.append(
+                    {'contrast': name,
+                     'stat': contrast_type,
+                     **out_ents}
+                    )
                 maps = flm.compute_contrast(
                     weights, contrast_type, output_type='all')
 
@@ -180,8 +179,6 @@ class SecondLevelModelInputSpec(BaseInterfaceInputSpec):
     stat_metadata = traits.List(traits.List(traits.Dict), mandatory=True)
     contrast_info = traits.List(traits.Dict, mandatory=True)
     smoothing_fwhm = traits.Float(desc='Full-width half max (FWHM) in mm for smoothing in mask')
-    drop_missing = traits.Bool(
-        desc='Drop missing inputs (i.e. contrasts) from previous level.')
 
 class SecondLevelModelOutputSpec(TraitedSpec):
     effect_maps = traits.List(File)
@@ -213,10 +210,6 @@ class SecondLevelModel(NistatsBaseInterface, SimpleInterface):
         smoothing_fwhm = self.inputs.smoothing_fwhm
         if not isdefined(smoothing_fwhm):
             smoothing_fwhm = None
-
-        drop_missing = self.inputs.drop_missing
-        if not isdefined(drop_missing):
-            drop_missing = False
 
         model = level2.SecondLevelModel(smoothing_fwhm=smoothing_fwhm)
 

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -211,33 +211,23 @@ class SecondLevelModel(NistatsBaseInterface, SecondLevelEstimatorInterface, Simp
                  'stat': contrast_type,
                  **out_ents})
 
-            if len(effects) == 1:
-                print("Passing through results from previous model,"
-                      "as only one is available")
-                effect_maps.append(effects[0])
-                variance_maps.append(_variances[0])
-                zscore_maps.append()
-                pvalue_maps.append()
-                stat_maps.append()
-            else:
-                design_matrix = pd.DataFrame(
-                    {'intercept': weights[weights != 0]})
+            design_matrix = pd.DataFrame(
+                {'intercept': weights[weights != 0]})
 
-                model.fit(effects, design_matrix=design_matrix)
+            model.fit(effects, design_matrix=design_matrix)
 
-                maps = model.compute_contrast(
-                    second_level_stat_type=contrast_type,
-                    output_type='all')
+            maps = model.compute_contrast(
+                second_level_stat_type=contrast_type,
+                output_type='all')
 
-
-                for map_type, map_list in (('effect_size', effect_maps),
-                                           ('effect_variance', variance_maps),
-                                           ('z_score', zscore_maps),
-                                           ('p_value', pvalue_maps),
-                                           ('stat', stat_maps)):
-                    fname = fname_fmt(name, map_type)
-                    maps[map_type].to_filename(fname)
-                    map_list.append(fname)
+            for map_type, map_list in (('effect_size', effect_maps),
+                                       ('effect_variance', variance_maps),
+                                       ('z_score', zscore_maps),
+                                       ('p_value', pvalue_maps),
+                                       ('stat', stat_maps)):
+                fname = fname_fmt(name, map_type)
+                maps[map_type].to_filename(fname)
+                map_list.append(fname)
 
         self._results['effect_maps'] = effect_maps
         self._results['variance_maps'] = variance_maps

--- a/fitlins/interfaces/utils.py
+++ b/fitlins/interfaces/utils.py
@@ -35,6 +35,7 @@ class MergeAll(IOBase):
             if self._check_lengths is True:
                 self._calculate_length(val)
             outputs[key] = [elem for sublist in val for elem in sublist]
+        self._lengths = None
 
         return outputs
 

--- a/fitlins/interfaces/utils.py
+++ b/fitlins/interfaces/utils.py
@@ -32,7 +32,6 @@ class MergeAll(IOBase):
         outputs = self._outputs().get()
         for key in self._fields:
             val = getattr(self.inputs, key)
-            self._calculate_length(val)
             if self._check_lengths is True:
                 self._calculate_length(val)
             outputs[key] = [elem for sublist in val for elem in sublist]

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -76,13 +76,17 @@ def build_report_dict(deriv_dir, work_dir, analysis):
                     key: val
                     for key, val in ents.items()
                     if key in ('subject', 'session', 'task', 'run') and val},
-                'contrasts': [
-                    {'name': displayify(contrast.name),
-                     'glassbrain': fl_layout.get(contrast=snake_to_camel(contrast.name),
-                                                 suffix='ortho', extension='png', **ents)[0].path}
-                    for contrast in contrasts]
+                'contrasts': []
                 }
 
+            for contrast in contrasts:
+                glassbrain = fl_layout.get(
+                    contrast=snake_to_camel(contrast.name),
+                    suffix='ortho', extension='png', **ents)
+                analysis['contrasts'].append(
+                    {'name': displayify(contrast.name),
+                     'glassbrain': glassbrain[0].path if glassbrain else None}
+                )
             report_step['analyses'].append(analysis)
 
             # Space doesn't apply to design/contrast matrices

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -248,6 +248,7 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
                     'zscore_maps': {'stat': 'z'},
                 }),
             name=f'collate_{level}_outputs')
+        collate.inputs.drop_missing = drop_missing
 
         ds_contrast_maps = pe.Node(
             BIDSDataSink(base_directory=out_dir,
@@ -262,6 +263,7 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
             name='ds_{}_contrast_plots'.format(level))
 
         if ix == 0:
+            model.inputs.drop_missing = drop_missing
             wf.connect([
                 (loader, select_entities, [('entities', 'inlist')]),
                 (select_entities, getter,  [('out', 'entities')]),
@@ -291,8 +293,6 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
                                 ('variance_maps', 'variance_maps'),
                                 ('contrast_metadata', 'stat_metadata')]),
             ])
-
-        model.inputs.drop_missing = drop_missing
 
         wf.connect([
             (loader, select_contrasts, [('contrast_info', 'inlist')]),

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -84,7 +84,7 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
             raise ValueError(f"Invalid smoothing level {smoothing_level}")
 
     design_matrix = pe.MapNode(
-        DesignMatrix(),
+        DesignMatrix(drop_missing=drop_missing),
         iterfield=['session_info', 'bold_file'],
         name='design_matrix')
 
@@ -271,7 +271,6 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
             name='ds_{}_contrast_plots'.format(level))
 
         if ix == 0:
-            model.inputs.drop_missing = drop_missing
             wf.connect([
                 (loader, select_entities, [('entities', 'inlist')]),
                 (select_entities, getter,  [('out', 'entities')]),

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -15,7 +15,8 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
                     desc=None, model=None, participants=None,
                     ignore=None, force_index=None,
                     smoothing=None,
-                    base_dir=None, name='fitlins_wf'):
+                    base_dir=None, name='fitlins_wf',
+                    drop_missing=False):
     wf = pe.Workflow(name=name, base_dir=base_dir)
 
     # Find the appropriate model file(s)
@@ -290,6 +291,8 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
                                 ('variance_maps', 'variance_maps'),
                                 ('contrast_metadata', 'stat_metadata')]),
             ])
+
+        model.inputs.drop_missing = drop_missing
 
         wf.connect([
             (loader, select_contrasts, [('contrast_info', 'inlist')]),


### PR DESCRIPTION
Fixes #176 

- Behavior is toggled by CLI flag (`--drop-missing`). By default, it crashes.
- In `FirstLevelModel`, empty columns are detected in design matrix.
- In higher level models, dropping missing inputs is handled by `MergeAll`.