### PR TITLE
RF: Abstract interfaces to simplify swappability

### DIFF
--- a/fitlins/interfaces/abstract.py
+++ b/fitlins/interfaces/abstract.py
@@ -1,0 +1,64 @@
+"""Abstract interfaces for design matrix creation and estimation
+
+Estimator tools should be subclassed from these interfaces, ensuring
+trivial swapping of one tool for another at single points. For example,
+if there is interest in comparing the design matrix construction between
+tools without changing estimators, a new ``DesignMatrixInterface``
+subclass can be written and swapped in without demanding that an estimator
+also be written.
+"""
+
+from nipype.interfaces.base import BaseInterface, TraitedSpec, File, traits
+
+
+class DesignMatrixInputSpec(TraitedSpec):
+    bold_file = File(exists=True, mandatory=True)
+    session_info = traits.Dict()
+
+
+class DesignMatrixOutputSpec(TraitedSpec):
+    design_matrix = File()
+
+
+class DesignMatrixInterface(BaseInterface):
+    input_spec = DesignMatrixInputSpec
+    output_spec = DesignMatrixOutputSpec
+
+
+class FirstLevelEstimatorInputSpec(TraitedSpec):
+    bold_file = File(exists=True, mandatory=True)
+    mask_file = File(exists=True)
+    design_matrix = File(exists=True, mandatory=True)
+    contrast_info = traits.List(traits.Dict)
+    smoothing_fwhm = traits.Float(desc='Full-width half max (FWHM) in mm for smoothing in mask')
+
+
+class EstimatorOutputSpec(TraitedSpec):
+    effect_maps = traits.List(File)
+    variance_maps = traits.List(File)
+    stat_maps = traits.List(File)
+    zscore_maps = traits.List(File)
+    pvalue_maps = traits.List(File)
+    contrast_metadata = traits.List(traits.Dict)
+
+
+class FirstLevelEstimatorInterface(BaseInterface):
+    input_spec = FirstLevelEstimatorInputSpec
+    output_spec = EstimatorOutputSpec
+
+
+class SecondLevelEstimatorInputSpec(TraitedSpec):
+    effect_maps = traits.List(traits.List(File(exists=True)), mandatory=True)
+    variance_maps = traits.List(traits.List(File(exists=True)))
+    stat_metadata = traits.List(traits.List(traits.Dict), mandatory=True)
+    contrast_info = traits.List(traits.Dict, mandatory=True)
+    smoothing_fwhm = traits.Float(desc='Full-width half max (FWHM) in mm for smoothing in mask')
+
+
+class SecondLevelEstimatorOutputSpec(EstimatorOutputSpec):
+    contrast_metadata = traits.List(traits.Dict)
+
+
+class SecondLevelEstimatorInterface(BaseInterface):
+    input_spec = SecondLevelEstimatorInputSpec
+    output_spec = SecondLevelEstimatorOutputSpec

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -2,10 +2,10 @@ import os
 import numpy as np
 import pandas as pd
 
-from nipype.interfaces.base import (
-    LibraryBaseInterface, SimpleInterface, BaseInterfaceInputSpec, TraitedSpec,
-    File, traits, isdefined
-    )
+from nipype.interfaces.base import LibraryBaseInterface, SimpleInterface, isdefined
+
+from .abstract import (
+    DesignMatrixInterface, FirstLevelEstimatorInterface, SecondLevelEstimatorInterface)
 
 
 class NistatsBaseInterface(LibraryBaseInterface):
@@ -32,32 +32,10 @@ def prepare_contrasts(contrasts, all_regressors):
     return out_contrasts
 
 
-class FirstLevelModelInputSpec(BaseInterfaceInputSpec):
-    bold_file = File(exists=True, mandatory=True)
-    mask_file = File(exists=True)
-    session_info = traits.Dict()
-    contrast_info = traits.List(traits.Dict)
-    smoothing_fwhm = traits.Float(desc='Full-width half max (FWHM) in mm for smoothing in mask')
-
-
-class FirstLevelModelOutputSpec(TraitedSpec):
-    effect_maps = traits.List(File)
-    variance_maps = traits.List(File)
-    stat_maps = traits.List(File)
-    zscore_maps = traits.List(File)
-    pvalue_maps = traits.List(File)
-    contrast_metadata = traits.List(traits.Dict)
-    design_matrix = File()
-
-
-class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
-    input_spec = FirstLevelModelInputSpec
-    output_spec = FirstLevelModelOutputSpec
-
+class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface):
     def _run_interface(self, runtime):
         import nibabel as nb
         from nistats import design_matrix as dm
-        from nistats import first_level_model as level1
         info = self.inputs.session_info
         img = nb.load(self.inputs.bold_file)
         vols = img.shape[3]
@@ -73,7 +51,8 @@ class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
         if info['dense'] not in (None, 'None'):
             dense = pd.read_hdf(info['dense'], key='dense')
             column_names = dense.columns.tolist()
-            drift_model = None if (('cosine00' in column_names) | ('cosine_00' in column_names)) else 'cosine'
+            drift_model = None if (('cosine00' in column_names) |
+                                   ('cosine_00' in column_names)) else 'cosine'
         else:
             dense = None
             column_names = None
@@ -90,6 +69,15 @@ class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
         mat.to_csv('design.tsv', sep='\t')
         self._results['design_matrix'] = os.path.join(runtime.cwd,
                                                       'design.tsv')
+        return runtime
+
+
+class FirstLevelModel(NistatsBaseInterface, FirstLevelEstimatorInterface, SimpleInterface):
+    def _run_interface(self, runtime):
+        import nibabel as nb
+        from nistats import first_level_model as level1
+        mat = pd.read_csv(self.inputs.design_matrix, delimiter='\t', index_col=0)
+        img = nb.load(self.inputs.bold_file)
 
         mask_file = self.inputs.mask_file
         if not isdefined(mask_file):
@@ -137,24 +125,6 @@ class FirstLevelModel(NistatsBaseInterface, SimpleInterface):
         return runtime
 
 
-class SecondLevelModelInputSpec(BaseInterfaceInputSpec):
-    effect_maps = traits.List(traits.List(File(exists=True)), mandatory=True)
-    variance_maps = traits.List(traits.List(File(exists=True)))
-    stat_metadata = traits.List(traits.List(traits.Dict), mandatory=True)
-    contrast_info = traits.List(traits.Dict, mandatory=True)
-    smoothing_fwhm = traits.Float(desc='Full-width half max (FWHM) in mm for smoothing in mask')
-
-
-class SecondLevelModelOutputSpec(TraitedSpec):
-    effect_maps = traits.List(File)
-    variance_maps = traits.List(File)
-    stat_maps = traits.List(File)
-    zscore_maps = traits.List(File)
-    pvalue_maps = traits.List(File)
-    contrast_metadata = traits.List(traits.Dict)
-    contrast_matrix = File()
-
-
 def _flatten(x):
     return [elem for sublist in x for elem in sublist]
 
@@ -166,10 +136,7 @@ def _match(query, metadata):
     return True
 
 
-class SecondLevelModel(NistatsBaseInterface, SimpleInterface):
-    input_spec = SecondLevelModelInputSpec
-    output_spec = SecondLevelModelOutputSpec
-
+class SecondLevelModel(NistatsBaseInterface, SecondLevelEstimatorInterface, SimpleInterface):
     def _run_interface(self, runtime):
         from nistats import second_level_model as level2
         smoothing_fwhm = self.inputs.smoothing_fwhm

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -11,7 +11,7 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
     from nipype.interfaces import utility as niu
     from ..interfaces.bids import (
         ModelSpecLoader, LoadBIDSModel, BIDSSelect, BIDSDataSink)
-    from ..interfaces.nistats import FirstLevelModel, SecondLevelModel
+    from ..interfaces.nistats import DesignMatrix, FirstLevelModel, SecondLevelModel
     from ..interfaces.visualizations import (
         DesignPlot, DesignCorrelationPlot, ContrastMatrixPlot, GlassBrainPlot)
     from ..interfaces.utils import MergeAll, CollateWithMetadata
@@ -82,9 +82,14 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
                                              for step in model_dict['Steps']):
             raise ValueError(f"Invalid smoothing level {smoothing_level}")
 
+    design_matrix = pe.MapNode(
+        DesignMatrix(),
+        iterfield=['session_info', 'bold_file'],
+        name='design_matrix')
+
     l1_model = pe.MapNode(
         FirstLevelModel(),
-        iterfield=['session_info', 'contrast_info', 'bold_file', 'mask_file'],
+        iterfield=['design_matrix', 'contrast_info', 'bold_file', 'mask_file'],
         name='l1_model')
 
     def _deindex(tsv):
@@ -179,12 +184,16 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
     #
     wf.connect([
         (loader, ds_model_warnings, [('warnings', 'in_file')]),
-        (loader, l1_model, [('design_info', 'session_info')]),
-        (getter, l1_model, [('mask_files', 'mask_file')]),
-        (l1_model, plot_design, [('design_matrix', 'data')]),
-        (l1_model, deindex_tsv, [('design_matrix', 'tsv')]),
+        (loader, design_matrix, [('design_info', 'session_info')]),
+        (getter, design_matrix, [('bold_files', 'bold_file')]),
+        (getter, l1_model, [('bold_files', 'bold_file'),
+                            ('mask_files', 'mask_file')]),
+        (design_matrix, l1_model, [('design_matrix', 'design_matrix')]),
+        (design_matrix, plot_design, [('design_matrix', 'data')]),
+        (design_matrix, plot_l1_contrast_matrix,  [('design_matrix', 'data')]),
+        (design_matrix, plot_corr,  [('design_matrix', 'data')]),
+        (design_matrix, deindex_tsv, [('design_matrix', 'tsv')]),
         (deindex_tsv, ds_design_matrix, [('out', 'in_file')]),
-        (getter, l1_model, [('bold_files', 'bold_file')]),
         ])
 
     stage = None
@@ -269,8 +278,6 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
                 (plot_design, ds_design, [('figure', 'in_file')]),
                 (select_contrasts, plot_l1_contrast_matrix,  [('out', 'contrast_info')]),
                 (select_contrasts, plot_corr,  [('out', 'contrast_info')]),
-                (model, plot_l1_contrast_matrix,  [('design_matrix', 'data')]),
-                (model, plot_corr,  [('design_matrix', 'data')]),
                 (select_entities, ds_l1_contrasts, [('out', 'entities')]),
                 (select_entities, ds_corr, [('out', 'entities')]),
                 (plot_l1_contrast_matrix, ds_l1_contrasts,  [('figure', 'in_file')]),


### PR DESCRIPTION
This is a first pass at abstracting interfaces, intended to ease #171, which reuses the nistats design matrix for the time being.

The goal is to try to move our interfaces away from the specifics of nistats to the inputs and outputs inherent to the processes at each stage. We may want to further refine the scope, or increase the range of abstract processes. For example, we could reduce the estimator outputs to effects, variances and metadata, and move stat, p and Z maps to a separate interface, which AFNI could implement with `3dPval`.