### PR TITLE
FIX: Set smoothing_fwhm after creating next level. Fixes #189

### DIFF
--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -209,9 +209,6 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
 
         level = 'l{:d}'.format(ix + 1)
 
-        if smoothing and smoothing_level in (step, level):
-            model.inputs.smoothing_fwhm = smoothing_fwhm
-
         # TODO: No longer used at higher level, suggesting we can simply return
         # entities from loader as a single list
         select_entities = pe.Node(
@@ -298,6 +295,9 @@ def init_fitlins_wf(bids_dir, derivatives, out_dir, analysis_level, space,
                                 ('variance_maps', 'variance_maps'),
                                 ('contrast_metadata', 'stat_metadata')]),
             ])
+
+        if smoothing and smoothing_level in (step, level):
+            model.inputs.smoothing_fwhm = smoothing_fwhm
 
         wf.connect([
             (loader, select_contrasts, [('contrast_info', 'inlist')]),


### PR DESCRIPTION
Fixes #189 

The `smoothing_fwhm` was applied to model before the next level's model was created. This resulted in the `Subject` level inputs being smoothing rather than `Dataset`