### PR TITLE
UX: Update logging levels

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -25,7 +25,7 @@ from ..workflows import init_fitlins_wf
 from ..utils import bids
 from ..viz.reports import build_report_dict, write_full_report
 
-logging.addLevelName(25, 'INFO')  # Add a new level between INFO and WARNING
+logging.addLevelName(25, 'IMPORTANT')  # Add a new level between INFO and WARNING
 logger = logging.getLogger('cli')
 logger.setLevel(25)
 
@@ -71,7 +71,11 @@ def get_parser():
                         help='processing stage to be runa (see BIDS-Apps specification).')
 
     # optional arguments
-    parser.add_argument('-v', '--version', action='version', version=verstr)
+    parser.add_argument('--version', action='version', version=verstr)
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help="increase log verbosity for each occurence, debug level is -vvv")
+    parser.add_argument('-q', '--quiet', action='count', default=0,
+                        help="decrease log verbosity for each occurence, debug level is -vvv")
 
     g_bids = parser.add_argument_group('Options for filtering BIDS queries')
     g_bids.add_argument('--participant-label', action='store', nargs='+', default=None,
@@ -121,10 +125,16 @@ def get_parser():
 
 
 def run_fitlins(argv=None):
+    from nipype import logging as nlogging
     warnings.showwarning = _warn_redirect
     opts = get_parser().parse_args(argv)
-    if opts.debug:
-        logger.setLevel(logging.DEBUG)
+
+    log_level = 25 + 5 * (opts.quiet - opts.verbose)
+    logger.setLevel(log_level)
+    nlogging.getLogger('nipype.workflow').setLevel(log_level)
+    nlogging.getLogger('nipype.interface').setLevel(log_level)
+    nlogging.getLogger('nipype.utils').setLevel(log_level)
+
     if not opts.space:
         # make it an explicit None
         opts.space = None


### PR DESCRIPTION
Change `-v` from `--version` to `--verbose`. Add `-q` flag as well.

Also set the log levels on nipype logs, which were for some reason silent. I'm guessing there was a change in default behavior in a recent nipype release...