### PR TITLE
Add desc=preproc as filter when finding preproc BOLD files

### DIFF
--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -398,13 +398,13 @@ class BIDSSelect(SimpleInterface):
 
             if len(bold_file) == 0:
                 raise FileNotFoundError(
-                    "Could not find BOLD file with entities {}"
-                    "".format(selectors))
+                    "Could not find BOLD file in {} with entities {}"
+                    "".format(layout.root, selectors))
             elif len(bold_file) > 1:
                 raise ValueError(
-                    "Non-unique BOLD file with entities {}.\n"
+                    "Non-unique BOLD file in {} with entities {}.\n"
                     "Matches:\n\t{}"
-                    "".format(selectors,
+                    "".format(layout.root, selectors,
                               "\n\t".join(
                                   '{} ({})'.format(
                                       f.path,

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -398,13 +398,13 @@ class BIDSSelect(SimpleInterface):
 
             if len(bold_file) == 0:
                 raise FileNotFoundError(
-                    "Could not find BOLD file in {} with entities {}"
-                    "".format(self.inputs.bids_dir, selectors))
+                    "Could not find BOLD file with entities {}"
+                    "".format(selectors))
             elif len(bold_file) > 1:
                 raise ValueError(
-                    "Non-unique BOLD file in {} with entities {}.\n"
+                    "Non-unique BOLD file with entities {}.\n"
                     "Matches:\n\t{}"
-                    "".format(self.inputs.bids_dir, selectors,
+                    "".format(selectors,
                               "\n\t".join(
                                   '{} ({})'.format(
                                       f.path,

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -231,7 +231,7 @@ class LoadBIDSModel(SimpleInterface):
             TR = ents.pop('RepetitionTime', None)  # Required field in seconds
             if TR is None:  # But is unreliable (for now?)
                 preproc_files = analysis.layout.get(
-                    extension=['.nii', '.nii.gz'], **ents)
+                    extension=['.nii', '.nii.gz'], desc='preproc', **ents)
                 if len(preproc_files) != 1:
                     raise ValueError('Too many BOLD files found')
 
@@ -393,7 +393,7 @@ class BIDSSelect(SimpleInterface):
         mask_files = []
         entities = []
         for ents in self.inputs.entities:
-            selectors = {**self.inputs.selectors, **ents}
+            selectors = {**self.inputs.selectors, 'desc': 'preproc', **ents}
             bold_file = layout.get(**selectors)
 
             if len(bold_file) == 0:


### PR DESCRIPTION
Related issue: https://github.com/bids-standard/pybids/issues/557

Stems from having `validate=False`, which we only used to do when necessary, but now is applied across the whole master Layout