### PR TITLE
FIX: FEMA input index should filter on rows, not columns.

### DIFF
--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -227,12 +227,14 @@ class SecondLevelModel(NistatsBaseInterface, SecondLevelEstimatorInterface, Simp
 
             # Pass-through happens automatically as it can handle 1 input
             if contrast_type == 'FEMA':
-                # Filter effects and variances based on weights
-                ix = weights[0].astype(bool)
+                # Index design identity matrix on non-zero contrasts weights
+                con_ix = weights[0].astype(bool)
+                # Index of all input files "involved" with that contrast
+                dm_ix = mat.iloc[:, con_ix].any(axis=1)
 
                 ffx_res = compute_fixed_effects(
-                    np.array(filtered_effects)[ix],
-                    np.array(filtered_variances)[ix]
+                    np.array(filtered_effects)[dm_ix],
+                    np.array(filtered_variances)[dm_ix]
                     )
 
                 maps = {


### PR DESCRIPTION
Unfortunately, I didn't test this thoroughly enough, and the update on the `FEMA` input file indexing was incorrect. I reverted to a more clear/optimized version of my original logic.

Consider the following:

```
filtered_effects = ['/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model0/text_effect_size.nii.gz',                                                                                                                         
 '/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model0/rmse_effect_size.nii.gz',                                                                                                                         
 '/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model0/speech_effect_size.nii.gz',                                                                                                                       
 '/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model1/text_effect_size.nii.gz',                                                                                                                         
 '/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model1/rmse_effect_size.nii.gz',                                                                                                                         
 '/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model1/speech_effect_size.nii.gz',                                                                                                                       
 '/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model2/text_effect_size.nii.gz',                                                                                                                         
 '/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model2/rmse_effect_size.nii.gz',                                                                                                                         
 '/tmp/tmpe9vfsb1a/fitlins_wf/l1_model/mapflow/_l1_model2/speech_effect_size.nii.gz']  

# After running `prepare_contrasts`
contrasts = [('rmse', array([[1, 0, 0]]), 'FEMA'),                                                                                                                                                                      
 ('speech+rmse', array([[1, 0, 1]]), 'FEMA')]

```
and the design matrix looks like:
```
In [26]: mat                                                                                                                                                                                                
Out[26]:                                                                                                                                                                                                    
   rmse  speech  text                                                                                                                                                                                       
0     0       0     1                                                                                                                                                                                       
1     1       0     0                                                                                                                                                                                       
2     0       1     0                                                                                                                                                                                       
3     0       0     1                                                                                                                                                                                       
4     1       0     0                                                                                                                                                                                       
5     0       1     0                                                                                                                                                                                       
6     0       0     1                                                                                                                                                                                       
7     1       0     0                                                                                                                                                                                       
8     0       1     0  
```

For the first contrast `[1, 0, 0]` , you want the files indicated by 1s in the `rmse` column. 

The current logic of `ix = weights[0].astype(bool)` yields:
```
Out[83]: array([ True, False, False])
```

which is not what we want, because it's not the correct shape for filtering `filtered_effects`.

I think this slipped past me because in my test analysis it just so happened that `filtered_effects` was of length 3, and it did not crash (although it probably filtered the wrong things).

Instead, we want to use that `ix` to filter `mat`.

```
con_ix = weights[0].astype(bool)
dm_ix = mat.iloc[:, con_ix].any(axis=1)
```

```
In [87]: dm_ix
Out[87]: 
0    False
1     True
2    False
3    False
4     True
5    False
6    False
7     True
8    False
dtype: bool
```

Now the reason that I added the `any(axis=1)`, is because of second contrast with weights `[1, 0, 1]`.

In this case we want to filter `mat` to select those two columns, and then select `any` rows that have a non-zero value in either columns:

```
In [98]: dm_ix
Out[98]: 
0     True
1     True
2    False
3     True
4     True
5    False
6     True
7     True
8    False
dtype: bool
```

Now, this might be a weird `FEMA` to specify, but it's theoretically valid.
