### PR TITLE
RF: Accommodate and use new pybids model specification

### DIFF
--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -232,7 +232,11 @@ class LoadBIDSModel(SimpleInterface):
         design_info = []
         contrast_info = []
         warnings = []
-        for sparse, dense, ents in step.get_design_matrix():
+        for node in step.get_nodes():
+            sparse = node.get_design_matrix(mode='sparse')
+            dense = node.get_design_matrix(mode='dense')
+            ents = node.entities.copy()
+
             info = {}
 
             # Metadata is now included in entities

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -65,7 +65,8 @@ def build_report_dict(deriv_dir, work_dir, analysis):
     for step in analysis.steps:
         report_step = {'name': step.level, 'analyses': []}
         report['steps'].append(report_step)
-        for _, _, ents in step.get_design_matrix():
+        for node in step.get_nodes():
+            ents = node.entities.copy()
             contrasts = step.get_contrasts(**ents)[0]
             for key in ('datatype', 'desc', 'suffix', 'extension',
                         'RepetitionTime', 'SkullStripped', 'TaskName'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pybids @ git+https://github.com/bids-standard/pybids.git@69362e716cc1f7433b282ba0949da9e5ddce513d


### PR DESCRIPTION
* [x] Restore functionality after pinning to bids-standard/pybids#548
* [ ] Switch to new model specification

cc @tyarkoni 