### PR TITLE
CI: Improve outputs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
               --build-arg VERSION="${CIRCLE_TAG:-$THISVERSION}" .
       - run:
           name: Verify executable can be run
-          command: docker run --rm -it poldracklab/fitlins:latest --help
+          command: docker run --rm poldracklab/fitlins:latest --help
       - run:
           name: Check version
           command: |
             THISVERSION=$( python3 -c 'import fitlins; print(fitlins.__version__)' )
             THISVERSION="${CIRCLE_TAG:-$THISVERSION}"
-            DOCKERVERSION=$(docker run --rm -it poldracklab/fitlins:latest --version \
+            DOCKERVERSION=$(docker run --rm poldracklab/fitlins:latest --version \
                            | tail -n 1 | sed -e 's/.*fit/fit/' -e 's/[\r\n]//g')
             echo "$THISVERSION"
             echo "$DOCKERVERSION"
@@ -160,7 +160,7 @@ jobs:
             mkdir -p /tmp/ds003/work /tmp/ds003/derivatives
             chmod 777 /tmp/ds003/work /tmp/ds003/derivatives
             export CONDA_PREFIX=/opt/miniconda-latest/envs/neuro
-            docker run --rm -it -v /tmp/data/ds003_fmriprep:/data:ro \
+            docker run --rm -v /tmp/data/ds003_fmriprep:/data:ro \
                 -v /tmp/ds003/derivatives:/out \
                 -v /tmp/ds003/work:/scratch \
                 -v /tmp/data/ds003_models:/models \
@@ -180,7 +180,7 @@ jobs:
             mkdir -p /tmp/ds003/work_dbf 
             chmod 777 /tmp/ds003/work_dbf /tmp/ds003/derivatives
             export CONDA_PREFIX=/opt/miniconda-latest/envs/neuro
-            docker run --rm -it -v /tmp/data/ds003_fmriprep:/data \
+            docker run --rm -v /tmp/data/ds003_fmriprep:/data \
                 -v /tmp/ds003/derivatives:/out \
                 -v /tmp/ds003/work_dbf:/scratch \
                 -v /tmp/data/ds003_models:/models \
@@ -200,7 +200,7 @@ jobs:
             mkdir -p /tmp/ds003/work_dbf2 
             chmod 777 /tmp/ds003/work_dbf2 /tmp/ds003/derivatives
             export CONDA_PREFIX=/opt/miniconda-latest/envs/neuro
-            docker run --rm -it -v /tmp/data/ds003_fmriprep:/data \
+            docker run --rm -v /tmp/data/ds003_fmriprep:/data \
                 -v /tmp/ds003/derivatives:/out \
                 -v /tmp/ds003/work_dbf2:/scratch \
                 -v /tmp/data/ds003_models:/models \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
                 $CONDA_PREFIX/bin/fitlins /data/sourcedata /out dataset \
                 -d /data -m /models/model-001_smdl.json -w /scratch \
                 --participant-label 01 02 03 --space MNI152NLin2009cAsym \
-                --n-cpus 2 --mem-gb 4
+                --n-cpus 2 --mem-gb 4 -vv
       - run:
           name: Run FitLins Database-file
           no_output_timeout: 2h
@@ -192,7 +192,7 @@ jobs:
                 $CONDA_PREFIX/bin/fitlins /data/sourcedata /out dataset \
                 -d /data -m /models/model-001_smdl.json -w /scratch \
                 --participant-label 01 02 03 --space MNI152NLin2009cAsym \
-                --n-cpus 2 --database-path /out/pybidsdb
+                --n-cpus 2 --database-path /out/pybidsdb -vv
       - run:
           name: Run FitLins Database-file_exists
           no_output_timeout: 2h
@@ -212,7 +212,7 @@ jobs:
                 $CONDA_PREFIX/bin/fitlins /data/sourcedata /out dataset \
                 -d /data -m /models/model-001_smdl.json -w /scratch \
                 --participant-label 01 02 03 --space MNI152NLin2009cAsym \
-                --n-cpus 2 --database-path /out/pybidsdb
+                --n-cpus 2 --database-path /out/pybidsdb -vv
       - run:
           name: Combine coverage and submit
           command: |


### PR DESCRIPTION
* Remove "-it" from docker runs to avoid the `^@^@` characters that often happen.
* Add verbosity to FitLins runs