### PR TITLE
FIX: Downgrade Sphinx to <3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,9 @@ install_requires =
 duecredit = duecredit
 test = coverage<5
 docs =
-    sphinx
-    sphinxcontrib-apidoc
-    sphinx-argparse
+    sphinx~=2.4
+    sphinxcontrib-apidoc=0.3.0
+    sphinx-argparse=0.2.5
     sphinx-nbexamples >=0.4.0
     texext
     m2r

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,13 +37,8 @@ duecredit = duecredit
 test = coverage<5
 docs =
     sphinx~=2.4
-<<<<<<< Updated upstream
-    sphinxcontrib-apidoc=0.3.0
-    sphinx-argparse=0.2.5
-=======
     sphinxcontrib-apidoc~=0.3.0
     sphinx-argparse~=0.2.5
->>>>>>> Stashed changes
     sphinx-nbexamples >=0.4.0
     texext
     m2r

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,13 @@ duecredit = duecredit
 test = coverage<5
 docs =
     sphinx~=2.4
+<<<<<<< Updated upstream
     sphinxcontrib-apidoc=0.3.0
     sphinx-argparse=0.2.5
+=======
+    sphinxcontrib-apidoc~=0.3.0
+    sphinx-argparse~=0.2.5
+>>>>>>> Stashed changes
     sphinx-nbexamples >=0.4.0
     texext
     m2r


### PR DESCRIPTION
Sphinx 3.0 was release which was causing the doc tests to fail. Downgrading to 2.4 and pinning latest versions of other doc packages.