### PR TITLE
Only drop modulation if needed

### DIFF
--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -80,7 +80,8 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
             sparse = pd.read_hdf(info['sparse'], key='sparse').rename(
                 columns={'condition': 'trial_type',
                          'amplitude': 'modulation'})
-            sparse = sparse.dropna(subset=['modulation'])  # Drop NAs
+            if 'modulation' in sparse.columns:
+                sparse = sparse.dropna(subset=['modulation'])  # Drop NAs
         else:
             sparse = None
 


### PR DESCRIPTION
FWIW I rebuilt the image and without this fix seemed to work so I think it's probably dependent on pandas versioning. 

Still, doesn't hurt to do this.