### PR TITLE
FIX: Sparse matrix should be in long format, and HRF should be None by default

### DIFF
--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -235,7 +235,7 @@ class LoadBIDSModel(SimpleInterface):
         for coll in step.get_collections():
             sparse = dense = None
             try:
-                sparse = coll.to_df(include_dense=False)
+                sparse = coll.to_df(include_dense=False, format='long')
             except ValueError:
                 pass
             try:

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -106,7 +106,7 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
             frame_times=np.arange(vols) * info['repetition_time'],
             events=sparse,
             add_regs=dense,
-            hrf_model=None,
+            hrf_model=None,  # XXX: Consider making an input spec parameter
             add_reg_names=column_names,
             drift_model=drift_model,
         )

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -106,6 +106,7 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
             frame_times=np.arange(vols) * info['repetition_time'],
             events=sparse,
             add_regs=dense,
+            hrf_model=None,
             add_reg_names=column_names,
             drift_model=drift_model,
         )


### PR DESCRIPTION
Fix #257 

See also: https://github.com/neuroscout/neuroscout-cli/issues/111

- Given that fitlins interprets the BIDS Stats Model, I don't think any convolution should be happening if you don't ask for it. 
Currently it is, for sparse variables. 
- Alternatively, we could move away from sparse variables entirely, and fully create the design matrix in pybids, and not even pass any sparse variables (and even throw an error if there are any?)