### PR TITLE
Make drift model configurable via CLI

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -135,6 +135,9 @@ def get_parser():
     g_other.add_argument("--estimator", action="store", type=str,
                          help="estimator to use to fit the model",
                          default="nistats", choices=["nistats", "afni"])
+    g_other.add_argument("--drift-model", action="store", type=str,
+                         help="specifies the desired drift model",
+                         default=None, choices=["polynomial", "cosine", None])
     g_other.add_argument("--error-ts", action='store_true', default=False,
                          help='save error time series for first level models.'
                         ' Currently only implemented for afni estimator.')
@@ -247,6 +250,7 @@ def run_fitlins(argv=None):
         space=opts.space, desc=opts.desc_label,
         participants=subject_list, base_dir=work_dir,
         smoothing=opts.smoothing, drop_missing=opts.drop_missing,
+        drift_model=opts.drift_model,
         estimator=opts.estimator, errorts=opts.error_ts
         )
     fitlins_wf.config = deepcopy(config.get_fitlins_config()._sections)

--- a/fitlins/interfaces/abstract.py
+++ b/fitlins/interfaces/abstract.py
@@ -15,7 +15,10 @@ class DesignMatrixInputSpec(TraitedSpec):
     bold_file = File(exists=True, mandatory=True)
     session_info = traits.Dict()
     drop_missing = traits.Bool(
-            desc='Drop columns in design matrix with all missing values')
+        desc='Drop columns in design matrix with all missing values')
+    drift_model = traits.String(
+        desc='Optional drift model to apply to design matrix'
+    )
 
 
 class DesignMatrixOutputSpec(TraitedSpec):

--- a/fitlins/interfaces/abstract.py
+++ b/fitlins/interfaces/abstract.py
@@ -16,7 +16,8 @@ class DesignMatrixInputSpec(TraitedSpec):
     session_info = traits.Dict()
     drop_missing = traits.Bool(
         desc='Drop columns in design matrix with all missing values')
-    drift_model = traits.String(
+    drift_model = traits.Either(
+        traits.String(), None,
         desc='Optional drift model to apply to design matrix'
     )
 

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -91,8 +91,6 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
                     'Use --drop-missing to drop before model fitting.')
 
             column_names = dense.columns.tolist()
-            drift_model = None if (('cosine00' in column_names) |
-                                   ('cosine_00' in column_names)) else 'cosine'
 
             if dense.empty:
                 dense = None
@@ -100,7 +98,6 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
         else:
             dense = None
             column_names = None
-            drift_model = 'cosine'
 
         mat = dm.make_first_level_design_matrix(
             frame_times=np.arange(vols) * info['repetition_time'],
@@ -108,7 +105,7 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
             add_regs=dense,
             hrf_model=None,  # XXX: Consider making an input spec parameter
             add_reg_names=column_names,
-            drift_model=drift_model,
+            drift_model=None   # drift model should be added using StatModel
         )
 
         mat.to_csv('design.tsv', sep='\t')

--- a/fitlins/interfaces/nistats.py
+++ b/fitlins/interfaces/nistats.py
@@ -66,6 +66,7 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
                 f"Unknown image type ({img.__class__.__name__}) <{self.inputs.bold_file}>")
 
         drop_missing = bool(self.inputs.drop_missing)
+        drift_model = self.inputs.drift_model
 
         if info['sparse'] not in (None, 'None'):
             sparse = pd.read_hdf(info['sparse'], key='sparse').rename(
@@ -91,6 +92,9 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
                     'Use --drop-missing to drop before model fitting.')
 
             column_names = dense.columns.tolist()
+            drift_model = None if (('cosine00' in column_names) |
+                                   ('cosine_00' in column_names)) else \
+                                       drift_model
 
             if dense.empty:
                 dense = None
@@ -105,7 +109,7 @@ class DesignMatrix(NistatsBaseInterface, DesignMatrixInterface, SimpleInterface)
             add_regs=dense,
             hrf_model=None,  # XXX: Consider making an input spec parameter
             add_reg_names=column_names,
-            drift_model=None   # drift model should be added using StatModel
+            drift_model=drift_model
         )
 
         mat.to_csv('design.tsv', sep='\t')

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -5,7 +5,7 @@ import warnings
 def init_fitlins_wf(database_path, out_dir, analysis_level, space,
                     desc=None, model=None, participants=None,
                     smoothing=None, drop_missing=False,
-                    estimator=None, errorts=False,
+                    estimator=None, errorts=False, drift_model=None,
                     base_dir=None, name='fitlins_wf'):
     from nipype.pipeline import engine as pe
     from nipype.interfaces import utility as niu
@@ -84,6 +84,8 @@ def init_fitlins_wf(database_path, out_dir, analysis_level, space,
         DesignMatrix(drop_missing=drop_missing),
         iterfield=['session_info', 'bold_file'],
         name='design_matrix')
+
+    model.inputs.drift_model = drift_model
 
     if estimator == 'afni':
         from ..interfaces.afni import FirstLevelModel


### PR DESCRIPTION
Closes #274 

I debated if this should be a CLI flag, but honestly the CLI is already feeling a bit bloated, and I think automatically doing anything to do the design matrix is against the design philosopy of BIDS StatsModel / fitlins. 