### PR TITLE
Temporarily pull pybids from github maintenance branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     nilearn~=0.7.1
     pandas>=0.19
     tables>=3.2.1
-    pybids>=0.13
+    pybids @ git+https://github.com/bids-standard/pybids@maint/0.13.x#egg=pybids
     jinja2
 
 [options.extras_require]


### PR DESCRIPTION
Meanwhile pybids 0.13.x maintenance branch is released, pin to github branch for development