### PR TITLE
ENH: Set prog name to fitlins, regardless of which CLI program was called

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -67,6 +67,7 @@ def get_parser():
     verstr = 'fitlins v{}'.format(__version__)
 
     parser = ArgumentParser(
+        prog='fitlins',
         description='FitLins: Workflows for Fitting Linear models to fMRI',
         formatter_class=RawTextHelpFormatter,
     )


### PR DESCRIPTION
This makes it so that `fitlins` is always display as the program name when the ArgParse throws an error.

This is needed because the way I call Fitlins (from neuroscout-cli), it will display "neuroscout" as the name of the program, which is confusing.

neuroscout passes unrecognized arguments forward to fitlins, and it's useful to get a direct error from fitlins' ArgParse to understand how to correct the call to neursocout-cli. 