### PR TITLE
Allow models with no name

### DIFF
--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -144,7 +144,7 @@ def write_full_report(report_dict, run_context, deriv_dir):
 
     model_name = snake_to_camel(report_dict['model']['name'])
     if model_name == "":
-        model_name = "unknown"
+        model_name = "Untitled"
     target_file = op.join(
         deriv_dir, fl_layout.build_path({'model': model_name}, PATH_PATTERNS, validate=False)
     )

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -144,7 +144,7 @@ def write_full_report(report_dict, run_context, deriv_dir):
 
     model_name = snake_to_camel(report_dict['model']['name'])
     if model_name == "":
-        model_name = "Untitled"
+        model_name = "untitled"
     target_file = op.join(
         deriv_dir, fl_layout.build_path({'model': model_name}, PATH_PATTERNS, validate=False)
     )

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -142,9 +142,11 @@ def write_full_report(report_dict, run_context, deriv_dir):
 
     tpl = env.get_template('data/full_report.tpl')
 
-    model = snake_to_camel(report_dict['model']['name'])
+    model_name = snake_to_camel(report_dict['model']['name'])
+    if model_name == "":
+        model_name = "unknown"
     target_file = op.join(
-        deriv_dir, fl_layout.build_path({'model': model}, PATH_PATTERNS, validate=False)
+        deriv_dir, fl_layout.build_path({'model': model_name}, PATH_PATTERNS, validate=False)
     )
     html = tpl.render(deroot({**report_dict, **run_context}, op.dirname(target_file)))
     Path(target_file).parent.mkdir(parents=True, exist_ok=True)

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -142,9 +142,7 @@ def write_full_report(report_dict, run_context, deriv_dir):
 
     tpl = env.get_template('data/full_report.tpl')
 
-    model_name = snake_to_camel(report_dict['model']['name'])
-    if model_name == "":
-        model_name = "untitled"
+    model_name = snake_to_camel(report_dict['model'].get('name') or "untitled")
     target_file = op.join(
         deriv_dir, fl_layout.build_path({'model': model_name}, PATH_PATTERNS, validate=False)
     )


### PR DESCRIPTION
This PR handles models with a `Name` field set to "". This technically should not be allowed, but I think it's nice to handle this gracefully.

Eventually, a validator should catch this (although technically empty string is still a way to define this REQUIRED key, so its arguably valid).

