### PR TITLE
PIN pybids 0.15.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     nilearn~=0.8.1
     pandas>=0.19
     tables>=3.2.1
-    pybids~=0.15.0
+    pybids~=0.15.1
     jinja2
 
 [options.extras_require]


### PR DESCRIPTION
I suggest we pin pybids 0.15.1 as that version changes the implicit handling of `groupby` variables in ways that can be fairly significant. It possible its more liberal than `0.15` and therefore "backwards compatible" so this may not be that urgent.