### PR TITLE
ENH: Add stat entity to pybids config

### DIFF
--- a/fitlins/data/fitlins.json
+++ b/fitlins/data/fitlins.json
@@ -1,22 +1,25 @@
 {
-    "name": "fitlins",
-    "entities": [
-        {
-            "name": "contrast",
-            "pattern": "[_/\\\\]contrast-([a-zA-Z0-9]+)"
-        },
-	{
-            "name": "level",
-            "pattern": "[_/\\\\]level-([a-zA-Z0-9]+)"
-        },
-	{
-
-            "name": "name",
-            "pattern": "[_/\\\\]name-([a-zA-Z0-9]+)"
-        },
-	{
-            "name": "node",
-            "pattern": "[_/\\\\]node-([a-zA-Z0-9]+)"
-        }
-    ]
+  "name": "fitlins",
+  "entities": [
+    {
+      "name": "contrast",
+      "pattern": "[_/\\\\]contrast-([a-zA-Z0-9]+)"
+    },
+    {
+      "name": "level",
+      "pattern": "[_/\\\\]level-([a-zA-Z0-9]+)"
+    },
+    {
+      "name": "name",
+      "pattern": "[_/\\\\]name-([a-zA-Z0-9]+)"
+    },
+    {
+      "name": "node",
+      "pattern": "[_/\\\\]node-([a-zA-Z0-9]+)"
+    },
+    {
+      "name": "stat",
+      "pattern": "[_/\\\\]stat-([a-zA-Z0-9]+)"
+    }
+  ]
 }


### PR DESCRIPTION
At some points we use level and name entities. I don't have the interest in figuring out why and pulling them out at this point, but we do also create files with the stat entity, so that should be added.