### PR TITLE
DOC: Add CIFTI usage to documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,3 +30,8 @@ Command-Line Arguments
    :prog: fitlins
    :nodefault:
    :nodefaultconst:
+
+A Note about Processing CIFTIs
+======================
+
+FitLins (as of v0.7.0) can process CIFTI outputs (e.g., from fMRIPrep's `--cifti-output` flag). For FitLins to load fMRIPrep CIFTI outputs, define `--space fsLR` and `--desc-label ""`. The FitLins statistical map outputs will be saved as `.dscalar.nii` images. Figures in the reports will include a surface representation as well as separate images for subcortical regions.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -32,7 +32,7 @@ Command-Line Arguments
    :nodefaultconst:
 
 A Note about Processing CIFTIs
-======================
+==============================
 
 FitLins (as of v0.7.0) can process CIFTI outputs (e.g., from fMRIPrep's ``--cifti-output`` flag).
 For FitLins to load fMRIPrep CIFTI outputs, define ``--space fsLR`` and ``--desc-label ""``.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,4 +34,4 @@ Command-Line Arguments
 A Note about Processing CIFTIs
 ======================
 
-FitLins (as of v0.7.0) can process CIFTI outputs (e.g., from fMRIPrep's `--cifti-output` flag). For FitLins to load fMRIPrep CIFTI outputs, define `--space fsLR` and `--desc-label ""`. The FitLins statistical map outputs will be saved as `.dscalar.nii` images. Figures in the reports will include a surface representation as well as separate images for subcortical regions.
+FitLins (as of v0.7.0) can process CIFTI outputs (e.g., from fMRIPrep's ``--cifti-output`` flag). For FitLins to load fMRIPrep CIFTI outputs, define ``--space fsLR`` and ``--desc-label ""``. The FitLins statistical map outputs will be saved as ``.dscalar.nii`` images. Figures in the reports will include a surface representation as well as separate images for subcortical regions.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,4 +34,7 @@ Command-Line Arguments
 A Note about Processing CIFTIs
 ======================
 
-FitLins (as of v0.7.0) can process CIFTI outputs (e.g., from fMRIPrep's ``--cifti-output`` flag). For FitLins to load fMRIPrep CIFTI outputs, define ``--space fsLR`` and ``--desc-label ""``. The FitLins statistical map outputs will be saved as ``.dscalar.nii`` images. Figures in the reports will include a surface representation as well as separate images for subcortical regions.
+FitLins (as of v0.7.0) can process CIFTI outputs (e.g., from fMRIPrep's ``--cifti-output`` flag).
+For FitLins to load fMRIPrep CIFTI outputs, define ``--space fsLR`` and ``--desc-label ""``.
+The FitLins statistical map outputs will be saved as ``.dscalar.nii`` images.
+Figures in the reports will include a surface representation as well as separate images for subcortical regions.


### PR DESCRIPTION
Having trouble getting the code segments to appear as code (usually surrounding with "`" works but I guess .rst is different?)