### PR TITLE
fix: Use DataFrame.loc correctly in visualizations

### DIFF
--- a/fitlins/interfaces/visualizations.py
+++ b/fitlins/interfaces/visualizations.py
@@ -100,11 +100,9 @@ class DesignCorrelationPlot(Visualization):
             if len(np.array(c['weights']).shape) > 1:
                 for cond in c['conditions']:
                     name = c['name'] + '_' + cond
-                    contrast_matrix.loc[name][c['conditions']] = c['weights'][
-                        c['conditions'].index(cond)
-                    ]
+                    contrast_matrix.loc[name, c['conditions']] = c['weights'][c['conditions'].index(cond)]
             else:
-                contrast_matrix.loc[c['name']][c['conditions']] = c['weights']
+                contrast_matrix.loc[c['name'], c['conditions']] = c['weights']
 
         all_cols = list(data.columns)
         evs = set(contrast_matrix.index)


### PR DESCRIPTION
Avoid future pandas 3.0 error. FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0! You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy. A typical example is when you are setting values in a column of a DataFrame, like:

df["col"][row_indexer] = value

Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy