### PR TITLE
fix: Find files without run entities

### DIFF
--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -361,6 +361,14 @@ class BIDSSelect(SimpleInterface):
         mask_files = []
         entities = []
         for ents in self.inputs.entities:
+            if 'run' in ents:
+                # Case: run is an integer (01, 1, etc.)
+                if isinstance(ents['run'], (int, float)):
+                    ents['run'] = [ents['run'], None]
+                # Case: run is a list with one element [1]
+                elif isinstance(ents['run'], list) and len(ents['run']) == 1:
+                    ents['run'].append(None)
+                    
             selectors = {'desc': 'preproc', **ents, **self.inputs.selectors}
             bold_file = layout.get(**selectors)
 

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -361,13 +361,11 @@ class BIDSSelect(SimpleInterface):
         mask_files = []
         entities = []
         for ents in self.inputs.entities:
-            if 'run' in ents:
-                # Case: run is an integer (01, 1, etc.)
-                if isinstance(ents['run'], (int, float)):
-                    ents['run'] = [ents['run'], None]
-                # Case: run is a list with one element [1]
-                elif isinstance(ents['run'], list) and len(ents['run']) == 1:
-                    ents['run'].append(None)
+            # Hack around implicit "run-1" being added to files without run entities
+            # This problem may be worth addressing in spec generation instead, but doing it here for now
+            # See https://github.com/poldracklab/fitlins/pull/411
+            if ents.get('run') in (1, [1]):
+                ents['run'] = [1, None]
                     
             selectors = {'desc': 'preproc', **ents, **self.inputs.selectors}
             bold_file = layout.get(**selectors)


### PR DESCRIPTION
Modifying the entities list for cases where run (single run tasks) is not available in file paths. Tested on single run and multi-run case (ds000009). Sets runs entity to None when information is not available.