### PR TITLE
[FIX] Fixes missing contrast maps in html reports (Issue #392)

### DIFF
--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -90,7 +90,13 @@ def build_report_dict(deriv_dir, work_dir, graph):
                     if k in ("name", "contrast"):
                         cents.update({k: to_alphanum(str(v))})
 
-                glassbrain = fl_layout.get(suffix='ortho', extension='png', **cents)
+                # Remove non-file entities from cents (level and name are workflow metadata, not file entities)
+                file_entities = {
+                    k: v for k, v in cents.items() if k not in ['level', 'name']
+                }
+                glassbrain = fl_layout.get(
+                    suffix='ortho', extension='png', **file_entities
+                )
 
                 analysis_dict['entities'] = {
                     key: val

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -90,8 +90,10 @@ def build_report_dict(deriv_dir, work_dir, graph):
                     if k in ("name", "contrast"):
                         cents.update({k: to_alphanum(str(v))})
 
-                # Remove non-file entities from cents (level and name are workflow metadata, not file entities)
-                file_entities = {k: v for k, v in cents.items() if k not in ['level', 'name']}
+                # Can't use cents directly since it has keys that are not filename entities
+                # Can't use contrast_info.entities directly since some formatting is done to make things filename friendly
+                file_entities = {key: val for key, val in cents.items() if key in contrast_info.entities}
+
                 glassbrain = fl_layout.get(suffix='ortho', extension='png', **file_entities)
 
                 analysis_dict['entities'] = {

--- a/fitlins/viz/reports.py
+++ b/fitlins/viz/reports.py
@@ -91,12 +91,8 @@ def build_report_dict(deriv_dir, work_dir, graph):
                         cents.update({k: to_alphanum(str(v))})
 
                 # Remove non-file entities from cents (level and name are workflow metadata, not file entities)
-                file_entities = {
-                    k: v for k, v in cents.items() if k not in ['level', 'name']
-                }
-                glassbrain = fl_layout.get(
-                    suffix='ortho', extension='png', **file_entities
-                )
+                file_entities = {k: v for k, v in cents.items() if k not in ['level', 'name']}
+                glassbrain = fl_layout.get(suffix='ortho', extension='png', **file_entities)
 
                 analysis_dict['entities'] = {
                     key: val


### PR DESCRIPTION
## Fix: 
Contrast map images not appearing in HTML reports
## Issues this should resolve:
https://github.com/poldracklab/fitlins/issues/392

## Problem: 
Contrast map images were not being displayed in HTML reports. Instead, the message "Missing contrast skipped (used: --drop-missing)" appeared even when images were successfully generated.
## Root Cause: 
The fl_layout.get() search was using workflow metadata entities (level and name) that don't exist in file paths, causing the search to fail.
## Solution: 
Filter out non-file entities (level and name) from the cents dictionary before using it in the fl_layout.get() search.
## Changes: 
Modified fitlins/viz/reports.py to create file_entities by filtering out level and name from cents, then use file_entities in the search instead of cents.
## Testing: 
Verified contrast map images now appear correctly in HTML reports for both run-level and session-level contrasts.
